### PR TITLE
Adjust how errors are handled

### DIFF
--- a/src/client/protoClient.ts
+++ b/src/client/protoClient.ts
@@ -121,16 +121,12 @@ export class TravelTimeProtoClient {
     const buffer = TimeFilterFastRequest.encode(message).finish();
     const rq = () => this.axiosInstance.post(this.buildRequestUrl(uri, request), buffer);
 
-    try {
-      const promise = this.rateLimiter.isEnabled() ? new Promise<Awaited<ReturnType<typeof rq>>>((resolve) => {
-        this.rateLimiter.addAndExecute(() => resolve(rq()), 1);
-      }) : rq();
-      const { data } = await promise;
-      const response = TimeFilterFastResponse.decode(data);
-      return response.toJSON() as TimeFilterFastProtoResponse;
-    } catch (e) {
-      throw new Error('Error while sending proto request');
-    }
+    const promise = this.rateLimiter.isEnabled() ? new Promise<Awaited<ReturnType<typeof rq>>>((resolve) => {
+      this.rateLimiter.addAndExecute(() => resolve(rq()), 1);
+    }) : rq();
+    const { data } = await promise;
+    const response = TimeFilterFastResponse.decode(data);
+    return response.toJSON() as TimeFilterFastProtoResponse;
   }
 
   timeFilterFast = async (request: TimeFilterFastProtoRequest) => this.readProtoFile()

--- a/src/client/protoClient.ts
+++ b/src/client/protoClient.ts
@@ -132,7 +132,7 @@ export class TravelTimeProtoClient {
   timeFilterFast = async (request: TimeFilterFastProtoRequest) => this.readProtoFile()
     .then(async (root) => this.handleProtoFile(root, this.baseUri, request));
 
-  timeFilterFastDistance = async (request: TimeFilterFastProtoDistanceRequest) => this.readProtoFile()
+  private timeFilterFastDistance = async (request: TimeFilterFastProtoDistanceRequest) => this.readProtoFile()
     .then(async (root) => this.handleProtoFile(root, this.protoDistanceUri, request, { useDistance: true }));
 
   setRateLimitSettings = (settings: Partial<RateLimitSettings>) => {

--- a/src/error.ts
+++ b/src/error.ts
@@ -35,12 +35,6 @@ export class TravelTimeError extends Error {
     if (this.isTravelTimeError(errorData)) {
       return new TravelTimeError(errorData);
     }
-    return new TravelTimeError({
-      description: 'Couldn\'t get data',
-      http_status: error?.response?.status || 500,
-      error_code: 1,
-      documentation_link: 'https://docs.traveltime.com/api/reference/error-codes',
-      additional_info: {},
-    });
+    return error;
   }
 }


### PR DESCRIPTION
- remove error block from proto client (since it only stated message, not the cause of it)
- throw original error instead of creating fake `TravelTimeError` which might be misleading
- remove distance endpoint since for now it's not supported 