### PR TITLE
chore: updating protobufjs to fix security vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "agentkeepalive": "^4.5.0",
         "axios": "^1.6.7",
-        "protobufjs": "^7.0.0"
+        "protobufjs": "^7.2.5"
       },
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^5.29.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "agentkeepalive": "^4.5.0",
     "axios": "^1.6.7",
-    "protobufjs": "^7.0.0"
+    "protobufjs": "^7.2.5"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.29.0",


### PR DESCRIPTION
Updating `protobuf` because of this CVE: https://nvd.nist.gov/vuln/detail/CVE-2023-36665