### PR TITLE
Extend TravelTimeError with makeProtoError factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -718,7 +718,7 @@ You can apply additional optional parameters to client constructor’s second ar
 If you need to change any of these parameters you can call setter methods: `travelTimeClient.setRateLimitSettings`.
 
 ```ts
-import { TravelTimeProtoClient, TimeFilterFastProtoRequest } from 'traveltime-api';
+import { TravelTimeError, TravelTimeProtoClient, TimeFilterFastProtoRequest } from 'traveltime-api';
 
 const travelTimeProtoClient = new TravelTimeProtoClient({
   apiKey: 'YOUR_APP_KEY',
@@ -750,18 +750,10 @@ const requestData: TimeFilterFastProtoRequest = {
 
 travelTimeProtoClient.timeFilterFast(requestData)
   .then((data) => console.log(data))
-  .catch((e) => {
-    const err = TravelTimeError.makeProtoError(e);
-    if (TravelTimeError.isTravelTimeError(err)) {
-      console.error(`Travel Time API proto request failed with error code: ${err.http_status}`);
-      console.error(`X-ERROR-CODE: ${err.error_code || 'Not provided'}`);
-      console.error(`X-ERROR-DETAILS: ${err.details || 'Not provided'}`);
-      console.error(`X-ERROR-MESSAGE: ${err.description || 'Not provided'}`);
-    } else {
-      console.error(err);
-    }
-  });
+  .catch((e) => console.error(TravelTimeError.makeProtoError(e)));
 ```
+
+See [TravelTime Error Response](#traveltime-error-response) for how to destructure `TravelTimeError` fields (`http_status`, `error_code`, `description`, `details`) from proto endpoints.
 
 #### Transportation Details
 
@@ -841,20 +833,10 @@ const requestData: GeohashFastProtoRequest = {
 
 travelTimeProtoClient.geohashFast(requestData)
   .then((data) => console.log(data))
-  .catch((e) => {
-    const err = TravelTimeError.makeProtoError(e);
-    if (TravelTimeError.isTravelTimeError(err)) {
-      console.error(`Travel Time API proto request failed with error code: ${err.http_status}`);
-      console.error(`X-ERROR-CODE: ${err.error_code || 'Not provided'}`);
-      console.error(`X-ERROR-DETAILS: ${err.details || 'Not provided'}`);
-      console.error(`X-ERROR-MESSAGE: ${err.description || 'Not provided'}`);
-    } else {
-      console.error(err);
-    }
-  });
+  .catch((e) => console.error(TravelTimeError.makeProtoError(e)));
 ```
 
-The same rate-limit options and transportation detail shapes documented under [Time Filter Fast (Proto)](#time-filter-fast-proto) apply here.
+The same rate-limit options and transportation detail shapes documented under [Time Filter Fast (Proto)](#time-filter-fast-proto) apply here. See [TravelTime Error Response](#traveltime-error-response) for how to destructure `TravelTimeError` fields (`http_status`, `error_code`, `description`, `details`) from proto endpoints.
 
 ### [Routes](https://traveltime.com/docs/api/reference/routes)
 Returns routing information between source and destinations.
@@ -1100,7 +1082,12 @@ travelTimeProtoClient.timeFilterFast(requestData)
   .catch((e) => {
     const err = TravelTimeError.makeProtoError(e);
     if (TravelTimeError.isTravelTimeError(err)) {
-      // your error handling logic — err.http_status, err.error_code, err.description, err.details
+      console.error(`Travel Time API proto request failed with error code: ${err.http_status}`);
+      console.error(`X-ERROR-CODE: ${err.error_code || 'Not provided'}`);
+      console.error(`X-ERROR-DETAILS: ${err.details || 'Not provided'}`);
+      console.error(`X-ERROR-MESSAGE: ${err.description || 'Not provided'}`);
+    } else {
+      console.error(err);
     }
   });
 ```

--- a/README.md
+++ b/README.md
@@ -751,17 +751,14 @@ const requestData: TimeFilterFastProtoRequest = {
 travelTimeProtoClient.timeFilterFast(requestData)
   .then((data) => console.log(data))
   .catch((e) => {
-    if (e.response && e.response.headers) {
-      const errorCode = e.response.headers['x-error-code'];
-      const errorDetails = e.response.headers['x-error-details'];
-      const errorMessage = e.response.headers['x-error-message'];
-
-      console.error(`Travel Time API proto request failed with error code: ${e.response.status}`);
-      console.error(`X-ERROR-CODE: ${errorCode || 'Not provided'}`);
-      console.error(`X-ERROR-DETAILS: ${errorDetails || 'Not provided'}`);
-      console.error(`X-ERROR-MESSAGE: ${errorMessage || 'Not provided'}`);
+    const err = TravelTimeError.makeProtoError(e);
+    if (TravelTimeError.isTravelTimeError(err)) {
+      console.error(`Travel Time API proto request failed with error code: ${err.http_status}`);
+      console.error(`X-ERROR-CODE: ${err.error_code || 'Not provided'}`);
+      console.error(`X-ERROR-DETAILS: ${err.details || 'Not provided'}`);
+      console.error(`X-ERROR-MESSAGE: ${err.description || 'Not provided'}`);
     } else {
-      console.error(e);
+      console.error(err);
     }
   });
 ```
@@ -1040,6 +1037,21 @@ travelTimeClient.mapInfo()
   .catch((e) => {
       if(TravelTimeError.isTravelTimeError(e)) {
       // your error handling logic
+    }
+  });
+```
+
+For proto endpoints, errors are delivered via response headers (`x-error-code`, `x-error-message`, `x-error-details`) rather than a JSON body. Use `TravelTimeError.makeProtoError` to convert an axios error into a `TravelTimeError` with those headers mapped onto the standard fields (`http_status`, `error_code`, `description`, plus the proto-only `details` string).
+
+```ts
+import { TravelTimeError } from 'traveltime-api';
+
+travelTimeProtoClient.timeFilterFast(requestData)
+  .then((data) => console.log(data))
+  .catch((e) => {
+    const err = TravelTimeError.makeProtoError(e);
+    if (TravelTimeError.isTravelTimeError(err)) {
+      // your error handling logic — err.http_status, err.error_code, err.description, err.details
     }
   });
 ```

--- a/README.md
+++ b/README.md
@@ -807,6 +807,55 @@ support extra configuration parameters.
 * `parking_time` - constant penalty to apply to simulate the difficulty of finding a parking spot.
   Optional. Cannot be greater than the global travel time limit.
 
+### [Geohash Fast (Proto)](https://docs.traveltime.com/api/start/geohash-proto)
+A fast version of geohash communicating using [protocol buffers](https://github.com/protocolbuffers/protobuf).
+
+Body attributes:
+* country: Return the results that are within the specified country.
+* departureLocation: Point of departure. Mutually exclusive with `arrivalLocation`.
+* arrivalLocation: Arrival point. Mutually exclusive with `departureLocation`.
+* transportation: Transportation type (literal) or type with details (object) for "pt" and "driving+pt" types. Matches the Time Filter Fast (Proto) shape above.
+* travelTime: Time limit.
+* resolution: Geohash resolution (cell size).
+* properties: Optional array of cell properties to return — any of `'min'`, `'max'`, `'mean'`.
+
+```ts
+import { TravelTimeError, TravelTimeProtoClient, GeohashFastProtoRequest } from 'traveltime-api';
+
+const travelTimeProtoClient = new TravelTimeProtoClient({
+  apiKey: 'YOUR_APP_KEY',
+  applicationId: 'YOUR_APP_ID',
+});
+
+const requestData: GeohashFastProtoRequest = {
+  country: 'uk',
+  departureLocation: {
+    lat: 51.508930,
+    lng: -0.131387,
+  },
+  transportation: 'driving+ferry',
+  travelTime: 7200,
+  resolution: 6,
+  properties: ['mean'],
+};
+
+travelTimeProtoClient.geohashFast(requestData)
+  .then((data) => console.log(data))
+  .catch((e) => {
+    const err = TravelTimeError.makeProtoError(e);
+    if (TravelTimeError.isTravelTimeError(err)) {
+      console.error(`Travel Time API proto request failed with error code: ${err.http_status}`);
+      console.error(`X-ERROR-CODE: ${err.error_code || 'Not provided'}`);
+      console.error(`X-ERROR-DETAILS: ${err.details || 'Not provided'}`);
+      console.error(`X-ERROR-MESSAGE: ${err.description || 'Not provided'}`);
+    } else {
+      console.error(err);
+    }
+  });
+```
+
+The same rate-limit options and transportation detail shapes documented under [Time Filter Fast (Proto)](#time-filter-fast-proto) apply here.
+
 ### [Routes](https://traveltime.com/docs/api/reference/routes)
 Returns routing information between source and destinations.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "traveltime-api",
-  "version": "7.3.3",
+  "version": "7.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "traveltime-api",
-      "version": "7.3.3",
+      "version": "7.4.0",
       "license": "MIT",
       "dependencies": {
         "agentkeepalive": "^4.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "traveltime-api",
-  "version": "7.3.3",
+  "version": "7.4.0",
   "description": "TravelTime API SDK for node js with TypeScript",
   "main": "target/index.js",
   "types": "target/index.d.ts",

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,10 +1,13 @@
 /* eslint-disable camelcase */
+import axios from 'axios';
+
 export interface TraveltimeErrorConstructor {
     http_status: number;
     error_code: number;
     description: string;
     documentation_link: string;
     additional_info: Record<string, any>
+    details?: string;
 }
 
 export class TravelTimeError extends Error {
@@ -13,9 +16,10 @@ export class TravelTimeError extends Error {
   description: string;
   documentation_link: string;
   additional_info: Record<string, any>;
+  details?: string;
 
   constructor({
-    http_status, error_code, description, documentation_link, additional_info,
+    http_status, error_code, description, documentation_link, additional_info, details,
   }: TraveltimeErrorConstructor) {
     super(description);
     this.name = 'TravelTimeError';
@@ -24,6 +28,7 @@ export class TravelTimeError extends Error {
     this.description = description;
     this.documentation_link = documentation_link;
     this.additional_info = additional_info;
+    this.details = details;
   }
 
   static isTravelTimeError(payload: any): payload is TraveltimeErrorConstructor {
@@ -34,6 +39,27 @@ export class TravelTimeError extends Error {
     const errorData = error?.response?.data;
     if (this.isTravelTimeError(errorData)) {
       return new TravelTimeError(errorData);
+    }
+    return error;
+  }
+
+  static makeProtoError(error: unknown) {
+    if (!axios.isAxiosError(error) || !error.response) return error;
+
+    const { headers, status } = error.response;
+    const errorCode = headers['x-error-code'];
+    const errorMessage = headers['x-error-message'];
+    const errorDetails = headers['x-error-details'];
+
+    if (errorCode !== undefined || errorMessage !== undefined) {
+      return new TravelTimeError({
+        http_status: status,
+        error_code: Number(errorCode),
+        description: errorMessage ?? '',
+        documentation_link: '',
+        additional_info: {},
+        details: errorDetails,
+      });
     }
     return error;
   }


### PR DESCRIPTION
## Summary
- Add `TravelTimeError.makeProtoError` that converts an axios error into a `TravelTimeError` by mapping `x-error-code`, `x-error-message`, `x-error-details` response headers onto the existing fields.
- Add optional `details?: string` on `TravelTimeError` / `TraveltimeErrorConstructor` to carry the proto-only details string (since it isn't a `Record`).
- Update README: use `makeProtoError` in the Time Filter Fast (Proto) example, add a new "Geohash Fast (Proto)" section, and document proto-specific error handling at the end of the TravelTime Error Response section.

Non-breaking: `TravelTimeProtoClient` still throws raw axios errors. Consumers can opt in by wrapping their catch with `TravelTimeError.makeProtoError(e)`. Wiring this into the proto client itself would be a breaking change and is deferred.