### PR TITLE
Add exclude_roads transportation parameter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "traveltime-api",
-  "version": "7.4.4",
+  "version": "7.4.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "traveltime-api",
-      "version": "7.4.4",
+      "version": "7.4.5",
       "license": "MIT",
       "dependencies": {
         "agentkeepalive": "^4.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "traveltime-api",
-  "version": "7.4.4",
+  "version": "7.4.5",
   "description": "TravelTime API SDK for node js with TypeScript",
   "main": "target/index.js",
   "types": "target/index.d.ts",

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -12,6 +12,7 @@ export type RoutesResponseFareTicketType = 'single' | 'week' | 'month' | 'year';
 export type TrafficModel = 'balanced' | 'optimistic' | 'pessimistic'
 export type TrafficModelFast = 'peak' | 'off_peak'
 export type IncludeRoadValues = 'track' | 'restricted'
+export type ExcludeRoadValues = 'toll'
 
 export type LocationRequest = {
   'id': string;
@@ -31,6 +32,7 @@ export type TransportationRequestCommons = {
    * - `restricted` - roads that are not publicly accessible and may require a special permit. By default all of these roads are excluded from the search.
    */
   'include_roads'?: Array<IncludeRoadValues>
+  'exclude_roads'?: Array<ExcludeRoadValues>
   'disable_border_crossing'?: boolean
   'pt_change_delay'?: number
   'walking_time'?: number
@@ -69,6 +71,7 @@ export type TransportationNoPtRequestCommons = {
    * - `restricted` - roads that are not publicly accessible and may require a special permit. By default all of these roads are excluded from the search.
    */
   'include_roads'?: Array<IncludeRoadValues>
+  'exclude_roads'?: Array<ExcludeRoadValues>
   'disable_border_crossing'?: boolean
   'boarding_time'?: number
 }


### PR DESCRIPTION
Adds the new `exclude_roads` request parameter (`toll`) to `TransportationRequestCommons` and `TransportationNoPtRequestCommons` — the shared transportation types behind time-map, distance-map, geohash/h3, time-filter (+ many-to-many matrix), routes, and all postcodes endpoints.