### PR TITLE
Redesign error model: sanitized errors, camelCase fields, isRetryable

### DIFF
--- a/README.md
+++ b/README.md
@@ -718,7 +718,7 @@ You can apply additional optional parameters to client constructor’s second ar
 If you need to change any of these parameters you can call setter methods: `travelTimeClient.setRateLimitSettings`.
 
 ```ts
-import { TravelTimeError, TravelTimeProtoClient, TimeFilterFastProtoRequest } from 'traveltime-api';
+import { TravelTimeProtoClient, TimeFilterFastProtoRequest } from 'traveltime-api';
 
 const travelTimeProtoClient = new TravelTimeProtoClient({
   apiKey: 'YOUR_APP_KEY',
@@ -750,10 +750,10 @@ const requestData: TimeFilterFastProtoRequest = {
 
 travelTimeProtoClient.timeFilterFast(requestData)
   .then((data) => console.log(data))
-  .catch((e) => console.error(TravelTimeError.makeProtoError(e)));
+  .catch((e) => console.error(e));
 ```
 
-See [TravelTime Error Response](#traveltime-error-response) for how to destructure `TravelTimeError` fields (`http_status`, `error_code`, `description`, `details`) from proto endpoints.
+Proto endpoint failures are thrown as `TravelTimeError` instances with the proto error headers already mapped onto its fields. See [TravelTime Error Response](#traveltime-error-response) for how to destructure `TravelTimeError` fields (`status`, `errorCode`, `description`, `details`) from proto endpoints.
 
 #### Transportation Details
 
@@ -812,7 +812,7 @@ Body attributes:
 * properties: Optional array of cell properties to return — any of `'min'`, `'max'`, `'mean'`.
 
 ```ts
-import { TravelTimeError, TravelTimeProtoClient, GeohashFastProtoRequest } from 'traveltime-api';
+import { TravelTimeProtoClient, GeohashFastProtoRequest } from 'traveltime-api';
 
 const travelTimeProtoClient = new TravelTimeProtoClient({
   apiKey: 'YOUR_APP_KEY',
@@ -833,10 +833,10 @@ const requestData: GeohashFastProtoRequest = {
 
 travelTimeProtoClient.geohashFast(requestData)
   .then((data) => console.log(data))
-  .catch((e) => console.error(TravelTimeError.makeProtoError(e)));
+  .catch((e) => console.error(e));
 ```
 
-The same rate-limit options and transportation detail shapes documented under [Time Filter Fast (Proto)](#time-filter-fast-proto) apply here. See [TravelTime Error Response](#traveltime-error-response) for how to destructure `TravelTimeError` fields (`http_status`, `error_code`, `description`, `details`) from proto endpoints.
+The same rate-limit options and transportation detail shapes documented under [Time Filter Fast (Proto)](#time-filter-fast-proto) apply here. See [TravelTime Error Response](#traveltime-error-response) for how to destructure `TravelTimeError` fields (`status`, `errorCode`, `description`, `details`) from proto endpoints.
 
 ### [Routes](https://traveltime.com/docs/api/reference/routes)
 Returns routing information between source and destinations.
@@ -1058,7 +1058,7 @@ travelTimeClient.supportedLocations({
 ```
 
 ### [TravelTime Error Response](https://docs.traveltime.com/api/reference/error-response)
-If an error occurred in TravelTime api you can use TravelTimeError object to check and destructure error into a standard format.
+All failures are thrown as `TravelTimeError` instances with camelCase fields: `status`, `errorCode`, `description`, `documentationLink`, `additionalInfo`, `details` and `isRetryable`. Client-side validation failures are thrown as `TravelTimeValidationError` and transport-level failures (timeouts, DNS errors, non-TravelTime-shaped HTTP responses) as `TravelTimeNetworkError` — both extend `TravelTimeError`. Errors never contain request or response objects, headers, or credentials, so they are safe to log and serialize; `toJSON()` emits the fields above for structured loggers.
 
 ```ts
 import { TravelTimeError } from 'traveltime-api';
@@ -1072,7 +1072,7 @@ travelTimeClient.mapInfo()
   });
 ```
 
-For proto endpoints, errors are delivered via response headers (`x-error-code`, `x-error-message`, `x-error-details`) rather than a JSON body. Use `TravelTimeError.makeProtoError` to convert an axios error into a `TravelTimeError` with those headers mapped onto the standard fields (`http_status`, `error_code`, `description`, plus the proto-only `details` string).
+For proto endpoints, errors are delivered via response headers (`x-error-code`, `x-error-message`, `x-error-details`) rather than a JSON body. The SDK maps those headers onto the standard fields for you (`status`, `errorCode`, `description`, plus the proto-only `details` string).
 
 ```ts
 import { TravelTimeError } from 'traveltime-api';
@@ -1080,14 +1080,13 @@ import { TravelTimeError } from 'traveltime-api';
 travelTimeProtoClient.timeFilterFast(requestData)
   .then((data) => console.log(data))
   .catch((e) => {
-    const err = TravelTimeError.makeProtoError(e);
-    if (TravelTimeError.isTravelTimeError(err)) {
-      console.error(`Travel Time API proto request failed with error code: ${err.http_status}`);
-      console.error(`X-ERROR-CODE: ${err.error_code || 'Not provided'}`);
-      console.error(`X-ERROR-DETAILS: ${err.details || 'Not provided'}`);
-      console.error(`X-ERROR-MESSAGE: ${err.description || 'Not provided'}`);
+    if (TravelTimeError.isTravelTimeError(e)) {
+      console.error(`Travel Time API proto request failed with status: ${e.status}`);
+      console.error(`X-ERROR-CODE: ${e.errorCode ?? 'Not provided'}`);
+      console.error(`X-ERROR-DETAILS: ${e.details || 'Not provided'}`);
+      console.error(`X-ERROR-MESSAGE: ${e.description || 'Not provided'}`);
     } else {
-      console.error(err);
+      console.error(e);
     }
   });
 ```

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -2,7 +2,7 @@ import axios, {
   AxiosInstance, AxiosRequestConfig, CreateAxiosDefaults,
 } from 'axios';
 import HttpAgent, { HttpsAgent } from 'agentkeepalive';
-import { TravelTimeError } from '../error';
+import { TravelTimeError, TravelTimeValidationError } from '../error';
 import {
   MapInfoResponse,
   GeocodingResponse,
@@ -113,7 +113,7 @@ export class TravelTimeClient {
       axiosInstance?: AxiosInstance
     },
   ) {
-    if (!(credentials.applicationId && credentials.apiKey)) throw new Error('Credentials must be valid');
+    if (!(credentials.applicationId && credentials.apiKey)) throw new TravelTimeValidationError('Credentials must be valid');
     this.applicationId = credentials.applicationId;
     this.apiKey = credentials.apiKey;
     this.rateLimiter = new RateLimiter(parameters?.rateLimitSettings);
@@ -163,7 +163,7 @@ export class TravelTimeClient {
           }, this.rateLimiter.getTimeBetweenRetries());
         });
       }
-      throw TravelTimeError.makeError(error);
+      throw TravelTimeError.fromJsonError(error);
     }
   }
 

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -239,17 +239,25 @@ export class TravelTimeClient {
   timeFilter = async (body: TimeFilterRequest) => this.request<TimeFilterResponse>('/time-filter', 'post', { body });
   timeFilterBatch = async (requests: TimeFilterRequest[]) => this.batch(this.timeFilter, requests);
   manyToManyMatrix = async (body: TimeFilterManyToManyMatrixRequest) => {
-    const requests = timeFilterManyToManyMatrixToRequest(body);
-    const responses = await this.timeFilterBatch(requests);
-    return timeFilterManyToManyMatrixResponseMapper(responses, body.coordsFrom.length, body.coordsTo.length, body.properties || ['travel_time']);
+    try {
+      const requests = timeFilterManyToManyMatrixToRequest(body);
+      const responses = await this.timeFilterBatch(requests);
+      return timeFilterManyToManyMatrixResponseMapper(responses, body.coordsFrom.length, body.coordsTo.length, body.properties || ['travel_time']);
+    } catch (error) {
+      throw TravelTimeError.fromJsonError(error);
+    }
   };
 
   timeFilterFast = async (body: TimeFilterFastRequest) => this.request<TimeFilterFastResponse>('/time-filter/fast', 'post', { body });
   timeFilterFastBatch = async (requests: TimeFilterFastRequest[]) => this.batch(this.timeFilterFast, requests);
   manyToManyMatrixFast = async (body: TimeFilterFastManyToManyMatrixRequest) => {
-    const requests = timeFilterFastManyToManyMatrixToRequest(body);
-    const responses = await this.timeFilterFastBatch(requests);
-    return timeFilterFastManyToManyMatrixResponseMapper(responses, body.coordsFrom.length, body.coordsTo.length, body.properties || ['travel_time']);
+    try {
+      const requests = timeFilterFastManyToManyMatrixToRequest(body);
+      const responses = await this.timeFilterFastBatch(requests);
+      return timeFilterFastManyToManyMatrixResponseMapper(responses, body.coordsFrom.length, body.coordsTo.length, body.properties || ['travel_time']);
+    } catch (error) {
+      throw TravelTimeError.fromJsonError(error);
+    }
   };
 
   timeFilterPostcodeDistricts = async (body: TimeFilterPostcodeDistrictsRequest) => this

--- a/src/client/matrixMapper.ts
+++ b/src/client/matrixMapper.ts
@@ -15,6 +15,18 @@ import {
 } from '../types/timeFilterMatrix';
 import { TravelTimeValidationError } from '../error';
 
+function validateMatrixRequest(body: { coordsFrom?: Coords[], coordsTo?: Coords[] } | undefined) {
+  if (!body || typeof body !== 'object') {
+    throw new TravelTimeValidationError('Request body must be an object');
+  }
+  if (!Array.isArray(body.coordsFrom)) {
+    throw new TravelTimeValidationError('coordsFrom must be an array of coordinates');
+  }
+  if (!Array.isArray(body.coordsTo)) {
+    throw new TravelTimeValidationError('coordsTo must be an array of coordinates');
+  }
+}
+
 function validateMaxSearchLimit(MAX_SEARCHES_LIMIT: number, maxSearchesPerRequest: number | undefined) {
   const maxSearches = maxSearchesPerRequest || MAX_SEARCHES_LIMIT;
   if (maxSearches > MAX_SEARCHES_LIMIT) {
@@ -71,6 +83,7 @@ const generateFromId = (indexFrom: number) => `from-${indexFrom}`;
 const generateToIds = (chunk: Coords[], chunkOffset: number) => chunk.map((_, iTo) => `to-${iTo + chunkOffset}`);
 
 export function timeFilterFastManyToManyMatrixToRequest(body: TimeFilterFastManyToManyMatrixRequest): TimeFilterFastRequest[] {
+  validateMatrixRequest(body);
   return generateRequestsFromChunks<TimeFilterFastRequest>({
     coordsFrom: body.coordsFrom,
     coordsTo: body.coordsTo,
@@ -123,6 +136,7 @@ export function timeFilterFastManyToManyMatrixResponseMapper(responses: BatchRes
 }
 
 export function timeFilterManyToManyMatrixToRequest(body: TimeFilterManyToManyMatrixRequest): TimeFilterRequest[] {
+  validateMatrixRequest(body);
   return generateRequestsFromChunks<TimeFilterRequest>({
     coordsFrom: body.coordsFrom,
     coordsTo: body.coordsTo,

--- a/src/client/matrixMapper.ts
+++ b/src/client/matrixMapper.ts
@@ -13,11 +13,12 @@ import {
 import {
   TimeFilterFastManyToManyMatrixRequest, TimeFilterFastManyToManyMatrixResponse, TimeFilterManyToManyMatrixRequest, TimeFilterManyToManyMatrixResponse,
 } from '../types/timeFilterMatrix';
+import { TravelTimeValidationError } from '../error';
 
 function validateMaxSearchLimit(MAX_SEARCHES_LIMIT: number, maxSearchesPerRequest: number | undefined) {
   const maxSearches = maxSearchesPerRequest || MAX_SEARCHES_LIMIT;
   if (maxSearches > MAX_SEARCHES_LIMIT) {
-    throw new Error(`Max number of searches is ${MAX_SEARCHES_LIMIT}`);
+    throw new TravelTimeValidationError(`Max number of searches is ${MAX_SEARCHES_LIMIT}`);
   }
   return maxSearches;
 }

--- a/src/client/protoClient.ts
+++ b/src/client/protoClient.ts
@@ -3,6 +3,7 @@ import axios, { AxiosInstance } from 'axios';
 import HttpAgent, { HttpsAgent } from 'agentkeepalive';
 import protobuf from 'protobufjs';
 import { Coords, Credentials } from '../types';
+import { TravelTimeError, TravelTimeValidationError } from '../error';
 import {
   DetailedTransportation,
   GeohashFastProtoCellProperty,
@@ -83,7 +84,7 @@ export class TravelTimeProtoClient {
     credentials: Credentials,
     parameters?: { rateLimitSettings?: Partial<RateLimitSettings>, baseUrl?: string },
   ) {
-    if (!(credentials.applicationId && credentials.apiKey)) throw new Error('Credentials must be valid');
+    if (!(credentials.applicationId && credentials.apiKey)) throw new TravelTimeValidationError('Credentials must be valid');
     this.applicationId = credentials.applicationId;
     this.apiKey = credentials.apiKey;
     this.baseURL = parameters?.baseUrl || DEFAULT_BASE_URL;
@@ -137,7 +138,7 @@ export class TravelTimeProtoClient {
 
   private validateTransportationMode(mode: TimeFilterFastProtoTransportation): void {
     if (!(mode in this.transportationMap)) {
-      throw new Error('Transportation mode is not supported');
+      throw new TravelTimeValidationError('Transportation mode is not supported');
     }
   }
 
@@ -154,7 +155,7 @@ export class TravelTimeProtoClient {
 
     // Verify modes match
     if (transportation.mode !== transportationMode) {
-      throw new Error(`Details can only be used with matching transportation type "${transportation.mode}"`);
+      throw new TravelTimeValidationError(`Details can only be used with matching transportation type "${transportation.mode}"`);
     }
 
     if (transportation.mode === 'pt') {
@@ -244,10 +245,10 @@ export class TravelTimeProtoClient {
     } = request;
 
     if (!departureLocation && !arrivalLocation) {
-      throw new Error('Either departureLocation or arrivalLocation must be provided');
+      throw new TravelTimeValidationError('Either departureLocation or arrivalLocation must be provided');
     }
     if (departureLocation && arrivalLocation) {
-      throw new Error('Only one of departureLocation or arrivalLocation can be provided');
+      throw new TravelTimeValidationError('Only one of departureLocation or arrivalLocation can be provided');
     }
 
     const transportationMode = this.extractTransportationMode(transportation);
@@ -302,47 +303,65 @@ export class TravelTimeProtoClient {
     }
   }
 
+  /**
+   * Decodes a proto response body. Decode failures mean the response was
+   * received but could not be read, so they are not retryable.
+   */
+  private decodeProtoResponse<T>(type: protobuf.Type, data: unknown): T {
+    try {
+      return type.decode(data as Uint8Array).toJSON() as T;
+    } catch {
+      throw new TravelTimeError({ description: 'Could not decode proto response', isRetryable: false });
+    }
+  }
+
   private async handleProtoFile(
     uri: string,
     request: TimeFilterFastProtoRequest | TimeFilterFastProtoDistanceRequest,
     options?: ProtoRequestBuildOptions,
   ): Promise<TimeFilterFastProtoResponse> {
-    const { requestMessage, requestUrl } = this.buildProtoRequest(request, uri, options);
-    const message = this.TimeFilterFastRequest.create(requestMessage);
-    const buffer = this.TimeFilterFastRequest.encode(message).finish();
+    try {
+      const { requestMessage, requestUrl } = this.buildProtoRequest(request, uri, options);
+      const message = this.TimeFilterFastRequest.create(requestMessage);
+      const buffer = this.TimeFilterFastRequest.encode(message).finish();
 
-    const rq = () => this.axiosInstance.post(requestUrl, buffer);
+      const rq = () => this.axiosInstance.post(requestUrl, buffer);
 
-    const promise = this.rateLimiter.isEnabled()
-      ? new Promise<Awaited<ReturnType<typeof rq>>>((resolve) => {
-        this.rateLimiter.addAndExecute(() => resolve(rq()), 1);
-      })
-      : rq();
+      const promise = this.rateLimiter.isEnabled()
+        ? new Promise<Awaited<ReturnType<typeof rq>>>((resolve) => {
+          this.rateLimiter.addAndExecute(() => resolve(rq()), 1);
+        })
+        : rq();
 
-    const { data } = await promise;
-    const response = this.TimeFilterFastResponse.decode(data);
-    return response.toJSON() as TimeFilterFastProtoResponse;
+      const { data } = await promise;
+      return this.decodeProtoResponse<TimeFilterFastProtoResponse>(this.TimeFilterFastResponse, data);
+    } catch (error) {
+      throw TravelTimeError.fromProtoError(error);
+    }
   }
 
   private async handleGeohashProtoFile(
     uri: string,
     request: GeohashFastProtoRequest,
   ): Promise<GeohashFastProtoResponse> {
-    const { requestMessage, requestUrl } = this.buildGeohashProtoRequest(request, uri);
-    const message = this.GeohashFastRequest.create(requestMessage);
-    const buffer = this.GeohashFastRequest.encode(message).finish();
+    try {
+      const { requestMessage, requestUrl } = this.buildGeohashProtoRequest(request, uri);
+      const message = this.GeohashFastRequest.create(requestMessage);
+      const buffer = this.GeohashFastRequest.encode(message).finish();
 
-    const rq = () => this.axiosInstance.post(requestUrl, buffer);
+      const rq = () => this.axiosInstance.post(requestUrl, buffer);
 
-    const promise = this.rateLimiter.isEnabled()
-      ? new Promise<Awaited<ReturnType<typeof rq>>>((resolve) => {
-        this.rateLimiter.addAndExecute(() => resolve(rq()), 1);
-      })
-      : rq();
+      const promise = this.rateLimiter.isEnabled()
+        ? new Promise<Awaited<ReturnType<typeof rq>>>((resolve) => {
+          this.rateLimiter.addAndExecute(() => resolve(rq()), 1);
+        })
+        : rq();
 
-    const { data } = await promise;
-    const response = this.GeohashFastResponse.decode(data);
-    return response.toJSON() as GeohashFastProtoResponse;
+      const { data } = await promise;
+      return this.decodeProtoResponse<GeohashFastProtoResponse>(this.GeohashFastResponse, data);
+    } catch (error) {
+      throw TravelTimeError.fromProtoError(error);
+    }
   }
 
   timeFilterFast = async (request: TimeFilterFastProtoRequest) => this.handleProtoFile(this.baseURL, request);

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,66 +1,224 @@
-/* eslint-disable camelcase */
+/* eslint-disable max-classes-per-file, no-use-before-define */
 import axios from 'axios';
 
-export interface TraveltimeErrorConstructor {
-    http_status: number;
-    error_code: number;
-    description: string;
-    documentation_link: string;
-    additional_info: Record<string, any>
-    details?: string;
-}
-
-export class TravelTimeError extends Error {
-  http_status: number;
+/**
+ * Shape of the TravelTime API JSON error response body.
+ * https://docs.traveltime.com/api/reference/error-response
+ */
+export interface TravelTimeApiErrorPayload {
+  http_status?: number;
   error_code: number;
   description: string;
-  documentation_link: string;
-  additional_info: Record<string, any>;
+  documentation_link?: string;
+  additional_info?: Record<string, any>;
+}
+
+export interface TravelTimeErrorParams {
+  description: string;
+  status?: number;
+  errorCode?: number;
+  documentationLink?: string;
+  additionalInfo?: Record<string, any>;
   details?: string;
+  isRetryable?: boolean;
+}
 
-  constructor({
-    http_status, error_code, description, documentation_link, additional_info, details,
-  }: TraveltimeErrorConstructor) {
-    super(description);
+function isRetryableStatus(status: number | undefined): boolean {
+  return status !== undefined && (status === 429 || status >= 500);
+}
+
+function isApiErrorPayload(payload: any): payload is TravelTimeApiErrorPayload {
+  return typeof payload === 'object'
+    && payload !== null
+    && typeof payload.error_code === 'number'
+    && typeof payload.description === 'string';
+}
+
+/**
+ * Reduces a request URL to origin + path. Strips the query string, the
+ * fragment, and any userinfo a caller may have embedded in a custom base URL.
+ */
+function sanitizeUrl(url: unknown): string | undefined {
+  if (typeof url !== 'string') return undefined;
+  try {
+    const parsed = new URL(url);
+    return `${parsed.origin}${parsed.pathname}`;
+  } catch {
+    // Relative path, as used by the JSON client
+    return url.split(/[?#]/)[0];
+  }
+}
+
+function parseNumericHeader(value: unknown): number | undefined {
+  if (typeof value !== 'string' || value.trim() === '') return undefined;
+  const parsed = Number(value);
+  return Number.isNaN(parsed) ? undefined : parsed;
+}
+
+/**
+ * Base error thrown by the SDK. Errors returned by the TravelTime API
+ * are thrown as instances of this class; local validation failures and
+ * transport failures are thrown as its subclasses.
+ *
+ * Instances never hold request or response objects, headers, or
+ * credentials — they are safe to log and serialize.
+ */
+export class TravelTimeError extends Error {
+  /** HTTP status code, when the failure came from an HTTP response. */
+  readonly status?: number;
+  /** TravelTime API error code, when the API provided one. */
+  readonly errorCode?: number;
+  readonly description: string;
+  readonly documentationLink?: string;
+  readonly additionalInfo?: Record<string, any>;
+  readonly details?: string;
+  /** True for 429, 5xx, and transport-level failures. */
+  readonly isRetryable: boolean;
+
+  constructor(params: TravelTimeErrorParams) {
+    super(params.description);
     this.name = 'TravelTimeError';
-    this.http_status = http_status;
-    this.error_code = error_code;
-    this.description = description;
-    this.documentation_link = documentation_link;
-    this.additional_info = additional_info;
-    this.details = details;
+    this.status = params.status;
+    this.errorCode = params.errorCode;
+    this.description = params.description;
+    this.documentationLink = params.documentationLink;
+    this.additionalInfo = params.additionalInfo;
+    this.details = params.details;
+    this.isRetryable = params.isRetryable ?? isRetryableStatus(params.status);
+    // Drop the constructor and factory frames so the stack starts at the caller
+    Error.captureStackTrace?.(this, new.target);
   }
 
-  static isTravelTimeError(payload: any): payload is TraveltimeErrorConstructor {
-    return !!payload && (!!payload.error_code && !!payload.description);
+  toJSON(): Record<string, any> {
+    return {
+      name: this.name,
+      message: this.message,
+      status: this.status,
+      errorCode: this.errorCode,
+      description: this.description,
+      documentationLink: this.documentationLink,
+      additionalInfo: this.additionalInfo,
+      details: this.details,
+      isRetryable: this.isRetryable,
+      stack: this.stack,
+    };
   }
 
-  static makeError(error: any) {
-    const errorData = error?.response?.data;
-    if (this.isTravelTimeError(errorData)) {
-      return new TravelTimeError(errorData);
-    }
-    return error;
+  static isTravelTimeError(error: unknown): error is TravelTimeError {
+    return error instanceof TravelTimeError;
   }
 
-  static makeProtoError(error: unknown) {
-    if (!axios.isAxiosError(error) || !error.response) return error;
-
-    const { headers, status } = error.response;
-    const errorCode = headers['x-error-code'];
-    const errorMessage = headers['x-error-message'];
-    const errorDetails = headers['x-error-details'];
-
-    if (errorCode !== undefined || errorMessage !== undefined) {
+  /**
+   * Maps a failure from a JSON API request to a `TravelTimeError`.
+   * Errors that are not TravelTime-shaped (timeouts, DNS failures,
+   * proxy errors, non-JSON 5xx pages) become `TravelTimeNetworkError`.
+   * Never returns the original error object.
+   */
+  static fromJsonError(error: unknown): TravelTimeError {
+    if (error instanceof TravelTimeError) return error;
+    const response = (error as any)?.response;
+    const data = response?.data;
+    if (isApiErrorPayload(data)) {
       return new TravelTimeError({
-        http_status: status,
-        error_code: Number(errorCode),
-        description: errorMessage ?? '',
-        documentation_link: '',
-        additional_info: {},
-        details: errorDetails,
+        status: typeof response.status === 'number' ? response.status : data.http_status,
+        errorCode: data.error_code,
+        description: data.description,
+        documentationLink: data.documentation_link,
+        additionalInfo: data.additional_info,
       });
     }
-    return error;
+    return TravelTimeNetworkError.from(error);
+  }
+
+  /**
+   * Maps a failure from a proto API request to a `TravelTimeError`,
+   * reading the `x-error-code`, `x-error-message` and `x-error-details`
+   * response headers. Failures without those headers become
+   * `TravelTimeNetworkError`. Never returns the original error object.
+   */
+  static fromProtoError(error: unknown): TravelTimeError {
+    if (error instanceof TravelTimeError) return error;
+    if (axios.isAxiosError(error) && error.response) {
+      const { headers, status } = error.response;
+      const errorCode = headers?.['x-error-code'];
+      const errorMessage = headers?.['x-error-message'];
+      const errorDetails = headers?.['x-error-details'];
+      if (errorCode !== undefined || errorMessage !== undefined) {
+        return new TravelTimeError({
+          status,
+          errorCode: parseNumericHeader(errorCode),
+          description: typeof errorMessage === 'string' && errorMessage.length > 0 ? errorMessage : `Proto request failed with status code ${status}`,
+          details: typeof errorDetails === 'string' ? errorDetails : undefined,
+        });
+      }
+    }
+    return TravelTimeNetworkError.from(error);
+  }
+}
+
+/**
+ * Thrown for client-side validation failures, before any request is made.
+ */
+export class TravelTimeValidationError extends TravelTimeError {
+  constructor(description: string) {
+    super({ description, isRetryable: false });
+    this.name = 'TravelTimeValidationError';
+  }
+}
+
+export interface TravelTimeNetworkErrorParams {
+  description: string;
+  code?: string;
+  status?: number;
+  url?: string;
+  isRetryable?: boolean;
+}
+
+/**
+ * Thrown for transport-level failures (timeouts, DNS errors, aborted
+ * connections) and for HTTP failures that do not carry a TravelTime
+ * error body. Holds only primitive, credential-free diagnostics.
+ */
+export class TravelTimeNetworkError extends TravelTimeError {
+  /** Low-level error code, e.g. `ECONNABORTED` or `ENOTFOUND`. */
+  readonly code?: string;
+  /** Request path, without the query string. */
+  readonly url?: string;
+
+  constructor(params: TravelTimeNetworkErrorParams) {
+    super({
+      description: params.description,
+      status: params.status,
+      isRetryable: params.isRetryable ?? (params.status === undefined ? true : isRetryableStatus(params.status)),
+    });
+    this.name = 'TravelTimeNetworkError';
+    this.code = params.code;
+    this.url = params.url;
+  }
+
+  toJSON(): Record<string, any> {
+    return { ...super.toJSON(), code: this.code, url: this.url };
+  }
+
+  /**
+   * Builds a sanitized `TravelTimeNetworkError` from an unknown failure,
+   * copying only primitive diagnostics so that no headers, auth data, or
+   * request/response objects can reach consumers.
+   */
+  static from(error: unknown): TravelTimeNetworkError {
+    if (axios.isAxiosError(error)) {
+      return new TravelTimeNetworkError({
+        description: error.message || 'Request failed',
+        code: error.code,
+        status: error.response?.status,
+        url: sanitizeUrl(error.config?.url),
+      });
+    }
+    // Not an axios error, so no transport failure was observed — most likely a
+    // local encode/decode or programming error, which retrying cannot fix
+    if (error instanceof Error) {
+      return new TravelTimeNetworkError({ description: error.message || error.name, isRetryable: false });
+    }
+    return new TravelTimeNetworkError({ description: typeof error === 'string' ? error : 'Unknown request failure', isRetryable: false });
   }
 }

--- a/tests/integration/errors.test.ts
+++ b/tests/integration/errors.test.ts
@@ -21,7 +21,7 @@ describe('errors', () => {
       expect.fail('Expected error to be thrown');
     } catch (error) {
       expect(error).toBeInstanceOf(TravelTimeError);
-      expect((error as TravelTimeError).http_status).toBe(422);
+      expect((error as TravelTimeError).status).toBe(422);
     }
   });
 });

--- a/tests/unit/error.test.ts
+++ b/tests/unit/error.test.ts
@@ -260,6 +260,19 @@ describe('error model', () => {
       })).rejects.toBeInstanceOf(TravelTimeValidationError);
     });
 
+    it('should reject a matrix request exceeding the max searches limit', async () => {
+      const client = new TravelTimeClient({ apiKey: 'key', applicationId: 'app' });
+      const body = {
+        coordsFrom: [{ lat: 51.5, lng: -0.1 }],
+        coordsTo: [{ lat: 51.6, lng: -0.2 }],
+        maxSearchesPerRequest: 100_001,
+        transportation: { type: 'driving' as const },
+      };
+
+      await expect(client.manyToManyMatrix(body as any)).rejects.toBeInstanceOf(TravelTimeValidationError);
+      await expect(client.manyToManyMatrixFast(body as any)).rejects.toBeInstanceOf(TravelTimeValidationError);
+    });
+
     it('should map errors thrown while building the request, not just while sending it', async () => {
       const client = new TravelTimeProtoClient({ apiKey: 'key', applicationId: 'app' });
       // departureLocation is required; a plain-JS caller can omit it and the

--- a/tests/unit/error.test.ts
+++ b/tests/unit/error.test.ts
@@ -273,6 +273,30 @@ describe('error model', () => {
       await expect(client.manyToManyMatrixFast(body as any)).rejects.toBeInstanceOf(TravelTimeValidationError);
     });
 
+    it('should reject malformed matrix input with a validation error naming the field', async () => {
+      const client = new TravelTimeClient({ apiKey: 'key', applicationId: 'app' });
+      const coords = [{ lat: 51.6, lng: -0.2 }];
+
+      await expect(client.manyToManyMatrix({ coordsTo: coords } as any))
+        .rejects.toThrow('coordsFrom must be an array of coordinates');
+      await expect(client.manyToManyMatrixFast({ coordsTo: coords } as any))
+        .rejects.toThrow('coordsFrom must be an array of coordinates');
+      await expect(client.manyToManyMatrix({ coordsFrom: coords } as any))
+        .rejects.toThrow('coordsTo must be an array of coordinates');
+      await expect(client.manyToManyMatrix(undefined as any))
+        .rejects.toThrow('Request body must be an object');
+
+      await expect(client.manyToManyMatrix({ coordsTo: coords } as any))
+        .rejects.toBeInstanceOf(TravelTimeValidationError);
+    });
+
+    it('should still accept empty coordinate arrays', async () => {
+      const client = new TravelTimeClient({ apiKey: 'key', applicationId: 'app' });
+      // zero searches means zero requests; this reached the API as an empty
+      // matrix before validation was added and must keep doing so
+      await expect(client.manyToManyMatrix({ coordsFrom: [], coordsTo: [] } as any)).resolves.toBeDefined();
+    });
+
     it('should map errors thrown while building the request, not just while sending it', async () => {
       const client = new TravelTimeProtoClient({ apiKey: 'key', applicationId: 'app' });
       // departureLocation is required; a plain-JS caller can omit it and the

--- a/tests/unit/error.test.ts
+++ b/tests/unit/error.test.ts
@@ -1,0 +1,296 @@
+import { describe, it, expect } from 'vitest';
+import util from 'node:util';
+import {
+  TravelTimeClient,
+  TravelTimeProtoClient,
+  TravelTimeError,
+  TravelTimeNetworkError,
+  TravelTimeValidationError,
+} from '../../src';
+
+const SENTINEL = 'SENTINEL-API-KEY-b8f2c611';
+
+function makeAxiosError(overrides: Record<string, any> = {}) {
+  const config = {
+    url: '/time-map',
+    method: 'post',
+    baseURL: 'https://api.traveltimeapp.com/v4',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Api-Key': SENTINEL,
+      Authorization: `Basic ${SENTINEL}`,
+    },
+    auth: { username: 'app-id', password: SENTINEL },
+  };
+  const request = { _header: `POST /time-map HTTP/1.1\r\nX-Api-Key: ${SENTINEL}\r\n` };
+  const error: any = new Error('Request failed with status code 500');
+  error.name = 'AxiosError';
+  error.isAxiosError = true;
+  error.code = 'ERR_BAD_RESPONSE';
+  error.config = config;
+  error.request = request;
+  error.response = {
+    status: 500,
+    statusText: 'Internal Server Error',
+    headers: {},
+    config,
+    request,
+    data: '<html>Internal Server Error</html>',
+  };
+  Object.assign(error, overrides);
+  return error;
+}
+
+function walkEnumerable(value: unknown, visit: (str: string) => void, seen = new Set<object>()) {
+  if (typeof value === 'string') {
+    visit(value);
+    return;
+  }
+  if (typeof value !== 'object' || value === null || seen.has(value)) return;
+  seen.add(value);
+  // getOwnPropertyNames also picks up non-enumerable props such as message/stack
+  Object.getOwnPropertyNames(value).forEach((key) => {
+    walkEnumerable((value as Record<string, unknown>)[key], visit, seen);
+  });
+}
+
+function expectNoSentinel(err: unknown) {
+  expect(JSON.stringify(err)).not.toContain(SENTINEL);
+  expect((err as Error).stack ?? '').not.toContain(SENTINEL);
+  expect(util.inspect(err, { depth: null })).not.toContain(SENTINEL);
+  walkEnumerable(err, (str) => expect(str).not.toContain(SENTINEL));
+}
+
+const apiErrorResponse = (status: number, data: Record<string, unknown>) => ({
+  response: { ...makeAxiosError().response, status, data },
+});
+
+const protoErrorResponse = (headers: Record<string, string>) => ({
+  response: { ...makeAxiosError().response, status: 400, headers },
+});
+
+describe('error model', () => {
+  describe('credential leak regression', () => {
+    it('should not leak credentials from a non-TravelTime-shaped HTTP failure (JSON client mapping)', () => {
+      const err = TravelTimeError.fromJsonError(makeAxiosError());
+      expect(err).toBeInstanceOf(TravelTimeNetworkError);
+      expectNoSentinel(err);
+    });
+
+    it('should not leak credentials from a TravelTime-shaped API error', () => {
+      const err = TravelTimeError.fromJsonError(makeAxiosError(apiErrorResponse(422, {
+        http_status: 422,
+        error_code: 10,
+        description: 'Invalid request',
+        documentation_link: 'https://docs.traveltime.com',
+        additional_info: { travel_time: ['out of range'] },
+      })));
+      expect(err).toBeInstanceOf(TravelTimeError);
+      expectNoSentinel(err);
+    });
+
+    it('should not leak credentials from a proto error with x-error headers', () => {
+      const err = TravelTimeError.fromProtoError(makeAxiosError(protoErrorResponse({
+        'x-error-code': '4',
+        'x-error-message': 'Invalid country',
+        'x-error-details': 'country not supported',
+      })));
+      expect(err).toBeInstanceOf(TravelTimeError);
+      expectNoSentinel(err);
+    });
+
+    it('should not leak credentials from a proto failure without x-error headers', () => {
+      const err = TravelTimeError.fromProtoError(makeAxiosError());
+      expect(err).toBeInstanceOf(TravelTimeNetworkError);
+      expect(err.status).toBe(500);
+      expectNoSentinel(err);
+    });
+
+    it('should not leak credentials from a transport failure with no response', () => {
+      const err = TravelTimeError.fromJsonError(makeAxiosError({
+        message: 'timeout of 1000ms exceeded',
+        code: 'ECONNABORTED',
+        response: undefined,
+      }));
+      expect(err).toBeInstanceOf(TravelTimeNetworkError);
+      expectNoSentinel(err);
+    });
+
+    it('should not echo a partially supplied key from credentials validation', () => {
+      try {
+        // eslint-disable-next-line no-new
+        new TravelTimeClient({ apiKey: SENTINEL, applicationId: '' });
+        expect.fail('Expected error to be thrown');
+      } catch (error) {
+        expect(error).toBeInstanceOf(TravelTimeValidationError);
+        expectNoSentinel(error);
+      }
+    });
+
+    it('should strip the query string, fragment and any userinfo from the recorded url', () => {
+      const relative = TravelTimeNetworkError.from(makeAxiosError({
+        config: { url: '/time-map?key=value#frag' },
+        response: undefined,
+      }));
+      expect(relative.url).toBe('/time-map');
+
+      const absolute = TravelTimeNetworkError.from(makeAxiosError({
+        config: { url: `https://app-id:${SENTINEL}@proxy.internal/api/v3/time-filter/fast/uk` },
+        response: undefined,
+      }));
+      expect(absolute.url).toBe('https://proxy.internal/api/v3/time-filter/fast/uk');
+      expectNoSentinel(absolute);
+    });
+  });
+
+  describe('JSON error mapping', () => {
+    it('should map API error body fields to camelCase fields', () => {
+      const err = TravelTimeError.fromJsonError(makeAxiosError(apiErrorResponse(422, {
+        http_status: 422,
+        error_code: 10,
+        description: 'Invalid request',
+        documentation_link: 'https://docs.traveltime.com',
+        additional_info: { travel_time: ['out of range'] },
+      })));
+
+      expect(err.status).toBe(422);
+      expect(err.errorCode).toBe(10);
+      expect(err.description).toBe('Invalid request');
+      expect(err.message).toBe('Invalid request');
+      expect(err.documentationLink).toBe('https://docs.traveltime.com');
+      expect(err.additionalInfo).toEqual({ travel_time: ['out of range'] });
+    });
+
+    it('should map a body with error_code 0 as a TravelTime API error, not a network error', () => {
+      const err = TravelTimeError.fromJsonError(makeAxiosError(apiErrorResponse(500, {
+        http_status: 500, error_code: 0, description: 'Internal error', documentation_link: '', additional_info: {},
+      })));
+
+      expect(err).not.toBeInstanceOf(TravelTimeNetworkError);
+      expect(err.errorCode).toBe(0);
+      expect(err.status).toBe(500);
+    });
+
+    it('should return an already-mapped TravelTimeError as-is', () => {
+      const original = new TravelTimeValidationError('bad input');
+      expect(TravelTimeError.fromJsonError(original)).toBe(original);
+      expect(TravelTimeError.fromProtoError(original)).toBe(original);
+    });
+  });
+
+  describe('proto error mapping', () => {
+    it('should map x-error headers onto error fields', () => {
+      const err = TravelTimeError.fromProtoError(makeAxiosError(protoErrorResponse({
+        'x-error-code': '4',
+        'x-error-message': 'Invalid country',
+        'x-error-details': 'country not supported',
+      })));
+
+      expect(err.status).toBe(400);
+      expect(err.errorCode).toBe(4);
+      expect(err.description).toBe('Invalid country');
+      expect(err.details).toBe('country not supported');
+    });
+
+    it('should not produce NaN when x-error-code is absent or not numeric', () => {
+      const missingCode = TravelTimeError.fromProtoError(makeAxiosError(protoErrorResponse({
+        'x-error-message': 'Invalid country',
+      })));
+      expect(missingCode.errorCode).toBeUndefined();
+      expect(missingCode.description).toBe('Invalid country');
+
+      const badCode = TravelTimeError.fromProtoError(makeAxiosError(protoErrorResponse({
+        'x-error-code': 'not-a-number',
+        'x-error-message': 'Invalid country',
+      })));
+      expect(badCode.errorCode).toBeUndefined();
+    });
+  });
+
+  it('should narrow caught errors with isTravelTimeError', () => {
+    expect(TravelTimeError.isTravelTimeError(new TravelTimeValidationError('bad'))).toBe(true);
+    expect(TravelTimeError.isTravelTimeError(TravelTimeNetworkError.from(new Error('boom')))).toBe(true);
+    expect(TravelTimeError.isTravelTimeError(new Error('boom'))).toBe(false);
+    // the pre-v8 guard matched this payload shape rather than a caught error
+    expect(TravelTimeError.isTravelTimeError({ error_code: 10, description: 'payload, not an error' })).toBe(false);
+    expect(TravelTimeError.isTravelTimeError(undefined)).toBe(false);
+  });
+
+  it('should compute isRetryable from the kind of failure', () => {
+    const notFound = makeAxiosError({ response: { ...makeAxiosError().response, status: 404 } });
+    const cases: Array<[string, TravelTimeError, boolean]> = [
+      ['429', new TravelTimeError({ description: 'too many requests', status: 429 }), true],
+      ['5xx', TravelTimeError.fromJsonError(makeAxiosError()), true],
+      ['other 4xx', new TravelTimeError({ description: 'unprocessable', status: 422 }), false],
+      ['4xx without a TravelTime body', TravelTimeNetworkError.from(notFound), false],
+      ['transport failure with no status', TravelTimeError.fromJsonError(makeAxiosError({
+        code: 'ENOTFOUND', response: undefined,
+      })), true],
+      ['validation failure', new TravelTimeValidationError('bad input'), false],
+      // no transport failure was observed, so retrying cannot help
+      ['non-axios failure', TravelTimeNetworkError.from(new TypeError('boom')), false],
+    ];
+
+    cases.forEach(([label, error, expected]) => {
+      expect(error.isRetryable, label).toBe(expected);
+    });
+  });
+
+  describe('client-side validation', () => {
+    it('should reject proto requests with an unsupported transportation mode', async () => {
+      const client = new TravelTimeProtoClient({ apiKey: 'key', applicationId: 'app' });
+      await expect(client.timeFilterFast({
+        country: 'uk',
+        departureLocation: { lat: 51.5, lng: -0.1 },
+        destinationCoordinates: [{ lat: 51.6, lng: -0.2 }],
+        transportation: 'rocket' as any,
+        travelTime: 3600,
+      })).rejects.toBeInstanceOf(TravelTimeValidationError);
+    });
+
+    it('should reject geohash proto requests with both departure and arrival locations', async () => {
+      const client = new TravelTimeProtoClient({ apiKey: 'key', applicationId: 'app' });
+      await expect(client.geohashFast({
+        country: 'uk',
+        departureLocation: { lat: 51.5, lng: -0.1 },
+        arrivalLocation: { lat: 51.6, lng: -0.2 },
+        transportation: 'driving',
+        travelTime: 3600,
+        resolution: 6,
+      })).rejects.toBeInstanceOf(TravelTimeValidationError);
+    });
+
+    it('should map errors thrown while building the request, not just while sending it', async () => {
+      const client = new TravelTimeProtoClient({ apiKey: 'key', applicationId: 'app' });
+      // departureLocation is required; a plain-JS caller can omit it and the
+      // request builder throws before any request is made
+      await expect(client.timeFilterFast({
+        country: 'uk',
+        destinationCoordinates: [{ lat: 51.6, lng: -0.2 }],
+        transportation: 'driving',
+        travelTime: 3600,
+      } as any)).rejects.toBeInstanceOf(TravelTimeError);
+    });
+
+    it('should not mark an undecodable proto response as retryable', async () => {
+      const client = new TravelTimeProtoClient({ apiKey: 'key', applicationId: 'app' });
+      // A response arrived, so the failure is permanent — retrying cannot help
+      (client as any).axiosInstance.post = async () => ({ data: Buffer.from([0xff, 0xff, 0xff, 0xff]) });
+
+      try {
+        await client.timeFilterFast({
+          country: 'uk',
+          departureLocation: { lat: 51.5, lng: -0.1 },
+          destinationCoordinates: [{ lat: 51.6, lng: -0.2 }],
+          transportation: 'driving',
+          travelTime: 3600,
+        });
+        expect.fail('Expected error to be thrown');
+      } catch (error) {
+        expect(error).toBeInstanceOf(TravelTimeError);
+        expect((error as TravelTimeError).isRetryable).toBe(false);
+        expect(error).not.toBeInstanceOf(TravelTimeNetworkError);
+      }
+    });
+  });
+});


### PR DESCRIPTION
`makeError` returned the raw axios error for any non-TravelTime-shaped failure, and the proto client had no `try`/`catch` at all. Those errors carry `config.headers['X-Api-Key']` and `config.auth.password`, so anything logging them wrote plaintext API keys.

Errors are now `TravelTimeError`, `TravelTimeValidationError` or `TravelTimeNetworkError`, holding only credential-free primitives. Adds `isRetryable` and `toJSON()`. Proto `x-error-*` headers are now mapped by the client instead of by the caller.

Breaking: fields are camelCase (`http_status` → `status`, `error_code` → `errorCode`, `documentation_link` → `documentationLink`, `additional_info` → `additionalInfo`); `makeError`/`makeProtoError` → `fromJsonError`/`fromProtoError`; `isTravelTimeError` checks `instanceof`, not payload shape.
