### PR TITLE
Replace axios with native fetch

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -29,7 +29,11 @@
         ],
       "import/prefer-default-export": "off",
       "lines-between-class-members": "off",
-      "max-len": "off"
+      "max-len": "off",
+      "no-await-in-loop": "off",
+      "max-classes-per-file": "off",
+      "no-use-before-define": "off",
+      "class-methods-use-this": "off"
     },
     "settings": {
         "import/extensions": [

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /dist
 main.ts
 *.tgz
+.env*

--- a/README.md
+++ b/README.md
@@ -45,20 +45,21 @@ const travelTimeClient = new TravelTimeClient({
 
 You can apply additional optional parameters to client constructor’s second argument `parameters` object:
  - `baseURL` [string] - you can change base URL of client. Default value is `https://api.traveltimeapp.com/v4`.
- - `axiosInstance` [object] - if needed, you can pass your own axios instance.
+ - `timeout` [number] - request timeout in milliseconds. Default is `120000`.
+ - `retry` [object] - controls the built-in retrying of `HTTP 429 Too Many Requests` responses, which backs off exponentially with jitter. Accepts `enabled` (default `true`; the built-in retry is turned off while the rate limiter is enabled, since the rate limiter does its own retrying), `maxRetries` (default `3`), `baseDelay` (default `1000` ms) and `maxDelay` (default `60000` ms).
  - `rateLimitSettings` [object] - in order to keep within [limits](https://docs.traveltime.com/api/overview/usage-limits) we suggest enabling this feature to reduce risk of receiving `HTTP 429 Too Many Requests` errors. When using rate limiter if the response status is `429` we will retry your request up to 3 times. This object accepts these arguments:
     - `enabled` [boolean] - pass `true` to enable rate limiter on this SDK instance. Default is set to `false`.
     - `hitsPerMinute` [number] - pass number that your plan supports. You can find what HPM your plan supports [here](https://docs.traveltime.com/api/overview/usage-limits#Hits-Per-Minute-HPM). If you are on custom plan and not sure of your limits feel free to contact us. Default value is `60`.
     - `retryCount` [number] - Determines how many times request should be repeated when API returns status `429`. Default is `3`.
     - `timeBetweenRetries` [number] - Determines how often retry should happen. Time units - `milliseconds`. Default is `1000`.
 
-If you need to change any of these parameters you can call setter methods: `travelTimeClient.setBaseURL`, `travelTimeClient.setRateLimitSettings`.
+Credentials and all of these parameters are fixed at construction time — create a new client instance to use different ones.
 
 ---
 
 Now you'll be able to call all TravelTime API endpoints from `travelTimeClient` instance.
 
-Every instance function returns Object with type of `Promise<AxiosResponse<EndpointResponseType>>`.
+Every instance function returns Object with type of `Promise<EndpointResponseType>`.
 
 #### Batch Processing
 
@@ -709,13 +710,16 @@ Body attributes:
 #### Advanced Options
 
 You can apply additional optional parameters to client constructor’s second argument `parameters` object:
+ - `baseUrl` [string] - you can change base URL of client. Default value is `https://proto.api.traveltimeapp.com/api/v3`.
+ - `timeout` [number] - request timeout in milliseconds. Default is `120000`.
+ - `retry` [object] - controls the built-in retrying of `HTTP 429 Too Many Requests` responses. Accepts `enabled` (default `true`; turned off while the rate limiter is enabled), `maxRetries` (default `3`), `baseDelay` (default `1000` ms) and `maxDelay` (default `60000` ms).
  - `rateLimitSettings` [object] - in order to keep within [limits](https://docs.traveltime.com/api/overview/usage-limits) we suggest enabling this feature to reduce risk of receiving `HTTP 429 Too Many Requests` errors. This object accepts these arguments:
     - `enabled` [boolean] - pass `true` to enable rate limiter on this SDK instance. Default is set to `false`.
     - `hitsPerMinute` [number] - pass number that your plan supports. You can find what HPM your plan supports [here](https://docs.traveltime.com/api/overview/usage-limits#Hits-Per-Minute-HPM). If you are on custom plan and not sure of your limits feel free to contact us. Default value is `60`.
     - `retryCount` [number] - Determines how many times request should be repeated when API returns status `429`. Default is `3`.
     - `timeBetweenRetries` [number] - Determines how often retry should happen. Time units - `milliseconds`. Default is `1000`.
 
-If you need to change any of these parameters you can call setter methods: `travelTimeClient.setRateLimitSettings`.
+Credentials and all of these parameters are fixed at construction time — create a new client instance to use different ones.
 
 ```ts
 import { TravelTimeProtoClient, TimeFilterFastProtoRequest } from 'traveltime-api';

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,6 @@
       "version": "8.0.0",
       "license": "MIT",
       "dependencies": {
-        "agentkeepalive": "^4.6.0",
-        "axios": "1.19.0",
         "protobufjs": "^8.7.1"
       },
       "devDependencies": {
@@ -909,29 +907,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/agentkeepalive": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
-      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
-      "license": "MIT",
-      "dependencies": {
-        "humanize-ms": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 8.0.0"
-      }
-    },
     "node_modules/ajv": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
@@ -1132,11 +1107,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
-    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -1151,17 +1121,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/axios": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.19.0.tgz",
-      "integrity": "sha512-ht/iuYZXEjFxLH/Hkezgd7m6JKlHHXEUSneaDz8uZe1Gj5QZtCnpyDsckvAiEnT89OEbCLmnte4R4sn7P0EKFw==",
-      "dependencies": {
-        "follow-redirects": "^1.16.0",
-        "form-data": "^4.0.6",
-        "https-proxy-agent": "^5.0.1",
-        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/balanced-match": {
@@ -1216,6 +1175,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -1293,17 +1253,6 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
-    },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -1401,6 +1350,7 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -1456,14 +1406,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -1511,6 +1453,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -1591,6 +1534,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -1600,6 +1544,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -1616,6 +1561,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -1628,6 +1574,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -2101,26 +2048,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/follow-redirects": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
-      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -2135,22 +2062,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/form-data": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
-      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.4",
-        "mime-types": "^2.1.35"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/fs.realpath": {
@@ -2177,6 +2088,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -2223,6 +2135,7 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.7.tgz",
       "integrity": "sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -2247,6 +2160,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -2362,6 +2276,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2425,6 +2340,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2437,6 +2353,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -2452,32 +2369,13 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
       "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/humanize-ms": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
-      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
-      "dependencies": {
-        "ms": "^2.0.0"
       }
     },
     "node_modules/ignore": {
@@ -3286,6 +3184,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3311,25 +3210,6 @@
       },
       "engines": {
         "node": ">=8.6"
-      }
-    },
-    "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/minimatch": {
@@ -3359,6 +3239,7 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -3678,15 +3559,6 @@
       },
       "engines": {
         "node": ">=12.0.0"
-      }
-    },
-    "node_modules/proxy-from-env": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
-      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/punycode": {
@@ -5514,22 +5386,6 @@
       "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
       "dev": true
     },
-    "agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "requires": {
-        "debug": "4"
-      }
-    },
-    "agentkeepalive": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
-      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
-      "requires": {
-        "humanize-ms": "^1.2.1"
-      }
-    },
     "ajv": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
@@ -5664,11 +5520,6 @@
       "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
       "dev": true
     },
-    "asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
-    },
     "available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -5676,17 +5527,6 @@
       "dev": true,
       "requires": {
         "possible-typed-array-names": "^1.0.0"
-      }
-    },
-    "axios": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.19.0.tgz",
-      "integrity": "sha512-ht/iuYZXEjFxLH/Hkezgd7m6JKlHHXEUSneaDz8uZe1Gj5QZtCnpyDsckvAiEnT89OEbCLmnte4R4sn7P0EKFw==",
-      "requires": {
-        "follow-redirects": "^1.16.0",
-        "form-data": "^4.0.6",
-        "https-proxy-agent": "^5.0.1",
-        "proxy-from-env": "^2.1.0"
       }
     },
     "balanced-match": {
@@ -5730,6 +5570,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
       "requires": {
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2"
@@ -5781,14 +5622,6 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
-    },
-    "combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "requires": {
-        "delayed-stream": "~1.0.0"
-      }
     },
     "concat-map": {
       "version": "0.0.1",
@@ -5862,6 +5695,7 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
       "requires": {
         "ms": "^2.1.3"
       }
@@ -5893,11 +5727,6 @@
         "has-property-descriptors": "^1.0.0",
         "object-keys": "^1.1.1"
       }
-    },
-    "delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
     },
     "detect-libc": {
       "version": "2.1.2",
@@ -5933,6 +5762,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
       "requires": {
         "call-bind-apply-helpers": "^1.0.1",
         "es-errors": "^1.3.0",
@@ -6001,12 +5831,14 @@
     "es-define-property": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true
     },
     "es-errors": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true
     },
     "es-module-lexer": {
       "version": "2.0.0",
@@ -6018,6 +5850,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
       "requires": {
         "es-errors": "^1.3.0"
       }
@@ -6026,6 +5859,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
       "requires": {
         "es-errors": "^1.3.0",
         "get-intrinsic": "^1.2.6",
@@ -6391,11 +6225,6 @@
       "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true
     },
-    "follow-redirects": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
-      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw=="
-    },
     "for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -6403,18 +6232,6 @@
       "dev": true,
       "requires": {
         "is-callable": "^1.2.7"
-      }
-    },
-    "form-data": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
-      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
-      "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.4",
-        "mime-types": "^2.1.35"
       }
     },
     "fs.realpath": {
@@ -6433,7 +6250,8 @@
     "function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true
     },
     "function.prototype.name": {
       "version": "1.1.8",
@@ -6465,6 +6283,7 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.7.tgz",
       "integrity": "sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==",
+      "dev": true,
       "requires": {
         "call-bind-apply-helpers": "^1.0.1",
         "es-define-property": "^1.0.1",
@@ -6482,6 +6301,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
       "requires": {
         "dunder-proto": "^1.0.1",
         "es-object-atoms": "^1.0.0"
@@ -6557,7 +6377,8 @@
     "gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true
     },
     "has-bigints": {
       "version": "1.1.0",
@@ -6592,12 +6413,14 @@
     "has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true
     },
     "has-tostringtag": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
       "requires": {
         "has-symbols": "^1.0.3"
       }
@@ -6606,25 +6429,9 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
       "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
       "requires": {
         "function-bind": "^1.1.2"
-      }
-    },
-    "https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "requires": {
-        "agent-base": "6",
-        "debug": "4"
-      }
-    },
-    "humanize-ms": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
-      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
-      "requires": {
-        "ms": "^2.0.0"
       }
     },
     "ignore": {
@@ -7082,7 +6889,8 @@
     "math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true
     },
     "merge2": {
       "version": "1.4.1",
@@ -7098,19 +6906,6 @@
       "requires": {
         "braces": "^3.0.3",
         "picomatch": "^2.3.1"
-      }
-    },
-    "mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
-    },
-    "mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "requires": {
-        "mime-db": "1.52.0"
       }
     },
     "minimatch": {
@@ -7131,7 +6926,8 @@
     "ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
     },
     "nanoid": {
       "version": "3.3.16",
@@ -7338,11 +7134,6 @@
       "requires": {
         "long": "^5.3.2"
       }
-    },
-    "proxy-from-env": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
-      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA=="
     },
     "punycode": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -27,8 +27,6 @@
   "author": "TravelTime <support@traveltime.com> (https://traveltime.com/)",
   "license": "MIT",
   "dependencies": {
-    "agentkeepalive": "^4.6.0",
-    "axios": "1.19.0",
     "protobufjs": "^8.7.1"
   },
   "devDependencies": {

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -1,8 +1,5 @@
-import axios, {
-  AxiosInstance, AxiosRequestConfig, CreateAxiosDefaults,
-} from 'axios';
-import HttpAgent, { HttpsAgent } from 'agentkeepalive';
 import { TravelTimeError, TravelTimeValidationError } from '../error';
+import { Transport, TransportRetryOptions } from '../core/transport';
 import {
   MapInfoResponse,
   GeocodingResponse,
@@ -45,16 +42,30 @@ import { GeohashFastRequest, GeohashFastResponse } from '../types/geohashFast';
 
 type HttpMethod = 'get' | 'post'
 
+type RequestConfig = {
+  params?: Record<string, unknown>
+  headers?: Record<string, string>
+}
+
 type RequestPayload = {
   body?: any
-  config?: AxiosRequestConfig
+  config?: RequestConfig
 }
 
 const DEFAULT_BASE_URL = 'https://api.traveltimeapp.com/v4';
-const sdkVersion = require('../../package.json').version;
 
-const defaultHttpsAgent = new HttpsAgent({ keepAlive: true, maxSockets: 100 });
-const defaultHttpAgent = new HttpAgent({ keepAlive: true, maxSockets: 100 });
+/**
+ * Decodes a response body: JSON when it parses, otherwise the raw text
+ * (e.g. the KML response formats).
+ */
+function parseResponseBody(body: Buffer): unknown {
+  const text = body.toString('utf8');
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
 
 function getHitAmountFromRequest(url: string, body: RequestPayload['body']) {
   switch (url) {
@@ -100,9 +111,7 @@ function endpointChecksHPM(url: string) {
 }
 
 export class TravelTimeClient {
-  private apiKey: string;
-  private applicationId: string;
-  private axiosInstance: AxiosInstance;
+  private transport: Transport;
   private rateLimiter: RateLimiter;
 
   constructor(
@@ -110,51 +119,41 @@ export class TravelTimeClient {
     parameters?: {
       baseURL?: string,
       rateLimitSettings?: Partial<RateLimitSettings>,
-      axiosInstance?: AxiosInstance
+      /** Request timeout in milliseconds. Default `120000`. */
+      timeout?: number,
+      /** HTTP 429 retry behaviour. On by default, unless the rate limiter is enabled — its own retry logic applies then. */
+      retry?: TransportRetryOptions,
     },
   ) {
     if (!(credentials.applicationId && credentials.apiKey)) throw new TravelTimeValidationError('Credentials must be valid');
-    this.applicationId = credentials.applicationId;
-    this.apiKey = credentials.apiKey;
     this.rateLimiter = new RateLimiter(parameters?.rateLimitSettings);
-    const headers: CreateAxiosDefaults['headers'] = {
-      'Content-Type': 'application/json',
-      'X-Application-Id': this.applicationId,
-      'X-Api-Key': this.apiKey,
-      'User-Agent': `Travel Time Nodejs SDK ${sdkVersion}`,
-    };
-    if (parameters?.axiosInstance) {
-      this.axiosInstance = parameters.axiosInstance;
-      if (!this.axiosInstance.defaults.baseURL) this.axiosInstance.defaults.baseURL = parameters?.baseURL ?? DEFAULT_BASE_URL;
-      this.axiosInstance.defaults.headers.common = {
-        ...headers,
-        ...this.axiosInstance.defaults.headers.common,
-      };
-    } else {
-      this.axiosInstance = axios.create({
-        baseURL: parameters?.baseURL ?? DEFAULT_BASE_URL,
-        maxBodyLength: Infinity,
-        maxContentLength: Infinity,
-        httpAgent: defaultHttpAgent,
-        httpsAgent: defaultHttpsAgent,
-        headers: {
-          common: headers,
-        },
-      });
-    }
+    this.transport = new Transport({
+      baseURL: parameters?.baseURL ?? DEFAULT_BASE_URL,
+      auth: { scheme: 'api-key', applicationId: credentials.applicationId, apiKey: credentials.apiKey },
+      timeout: parameters?.timeout,
+      retry: { enabled: !this.rateLimiter.isEnabled(), ...parameters?.retry },
+    });
   }
 
   private async request<Response>(url: string, method: HttpMethod, payload?: RequestPayload, retryCount = 0): Promise<Response> {
     const { body, config } = payload || {};
-    const rq = () => (method === 'get' ? this.axiosInstance[method]<Response>(url, config) : this.axiosInstance[method]<Response>(url, body, config));
+    const rq = async (): Promise<Response> => {
+      const response = await this.transport.request(url, {
+        method: method === 'get' ? 'GET' : 'POST',
+        query: config?.params,
+        headers: config?.headers,
+        body: body === undefined ? undefined : JSON.stringify(body),
+      });
+      return parseResponseBody(response.body) as Response;
+    };
     try {
-      const promise = (this.rateLimiter.isEnabled() && endpointChecksHPM(url)) ? new Promise<Awaited<ReturnType<typeof rq>>>((resolve) => {
+      const promise = (this.rateLimiter.isEnabled() && endpointChecksHPM(url)) ? new Promise<Response>((resolve) => {
         this.rateLimiter.addAndExecute(() => resolve(rq()), getHitAmountFromRequest(url, body || {}), retryCount > 0);
       }) : rq();
-      const { data } = await promise;
+      const data = await promise;
       return data;
     } catch (error) {
-      if (this.rateLimiter.isEnabled() && retryCount < this.rateLimiter.getRetryCount() && axios.isAxiosError(error) && error.response?.status === 429) {
+      if (this.rateLimiter.isEnabled() && retryCount < this.rateLimiter.getRetryCount() && TravelTimeError.isTravelTimeError(error) && error.status === 429) {
         return new Promise((resolve) => {
           this.rateLimiter.setIsSleeping(true);
           setTimeout(() => {
@@ -163,11 +162,10 @@ export class TravelTimeClient {
           }, this.rateLimiter.getTimeBetweenRetries());
         });
       }
-      throw TravelTimeError.fromJsonError(error);
+      throw TravelTimeError.from(error);
     }
   }
 
-  // eslint-disable-next-line class-methods-use-this
   private async batch<T extends GenericFunction, R extends Awaited<ReturnType<T>>>(
     requestFn: T,
     bodies: Parameters<T>[0][],
@@ -244,7 +242,7 @@ export class TravelTimeClient {
       const responses = await this.timeFilterBatch(requests);
       return timeFilterManyToManyMatrixResponseMapper(responses, body.coordsFrom.length, body.coordsTo.length, body.properties || ['travel_time']);
     } catch (error) {
-      throw TravelTimeError.fromJsonError(error);
+      throw TravelTimeError.from(error);
     }
   };
 
@@ -256,7 +254,7 @@ export class TravelTimeClient {
       const responses = await this.timeFilterFastBatch(requests);
       return timeFilterFastManyToManyMatrixResponseMapper(responses, body.coordsFrom.length, body.coordsTo.length, body.properties || ['travel_time']);
     } catch (error) {
-      throw TravelTimeError.fromJsonError(error);
+      throw TravelTimeError.from(error);
     }
   };
 
@@ -310,25 +308,6 @@ export class TravelTimeClient {
   ): Promise<BatchResponse<Awaited<TimeMapFastResponseType[T]>>[]> {
     return this.batch((body: TimeMapFastRequest) => this.timeMapFast(body, format as T), bodies);
   }
-
-  getBaseURL = () => this.axiosInstance.defaults.baseURL;
-
-  /**
-   *
-   * @param baseURL Set new base URL. Pass nothing to reset to default
-   */
-  setBaseURL = (baseURL = DEFAULT_BASE_URL) => {
-    this.axiosInstance.defaults.baseURL = baseURL;
-  };
-
-  setRateLimitSettings = (settings: Partial<RateLimitSettings>) => {
-    this.rateLimiter.setRateLimitSettings(settings);
-  };
-
-  setCredentials = (credentials: Credentials) => {
-    this.apiKey = credentials.apiKey;
-    this.applicationId = credentials.applicationId;
-  };
 
   h3 = async (body: H3Request) => this
     .request<H3Response>('/h3', 'post', { body });

--- a/src/client/protoClient.ts
+++ b/src/client/protoClient.ts
@@ -1,9 +1,7 @@
-/* eslint-disable class-methods-use-this */
-import axios, { AxiosInstance } from 'axios';
-import HttpAgent, { HttpsAgent } from 'agentkeepalive';
 import protobuf from 'protobufjs';
 import { Coords, Credentials } from '../types';
 import { TravelTimeError, TravelTimeValidationError } from '../error';
+import { Transport, TransportRetryOptions } from '../core/transport';
 import {
   DetailedTransportation,
   GeohashFastProtoCellProperty,
@@ -36,9 +34,6 @@ interface TimeFilterFastProtoMessage {
 
 const DEFAULT_BASE_URL = 'https://proto.api.traveltimeapp.com/api/v3';
 
-const defaultHttpsAgent = new HttpsAgent({ keepAlive: true, maxSockets: 100 });
-const defaultHttpAgent = new HttpAgent({ keepAlive: true, maxSockets: 100 });
-
 interface ProtoRequestBuildOptions {
   useDistance?: boolean
 }
@@ -54,10 +49,7 @@ interface TimeFilterProtoMessageWithUrl {
 }
 
 export class TravelTimeProtoClient {
-  private apiKey: string;
-  private applicationId: string;
-  private axiosInstance: AxiosInstance;
-  private baseURL: string;
+  private transport: Transport;
   private protoFileDir = `${__dirname}/proto/v2`;
   private transportationMap: Record<TimeFilterFastProtoTransportation, TransportationConfig> = {
     pt: { code: 0, urlName: 'pt' },
@@ -82,26 +74,27 @@ export class TravelTimeProtoClient {
 
   constructor(
     credentials: Credentials,
-    parameters?: { rateLimitSettings?: Partial<RateLimitSettings>, baseUrl?: string },
+    parameters?: {
+      rateLimitSettings?: Partial<RateLimitSettings>,
+      baseUrl?: string,
+      /** Request timeout in milliseconds. Default `120000`. */
+      timeout?: number,
+      /** HTTP 429 retry behaviour. On by default, unless the rate limiter is enabled. */
+      retry?: TransportRetryOptions,
+    },
   ) {
     if (!(credentials.applicationId && credentials.apiKey)) throw new TravelTimeValidationError('Credentials must be valid');
-    this.applicationId = credentials.applicationId;
-    this.apiKey = credentials.apiKey;
-    this.baseURL = parameters?.baseUrl || DEFAULT_BASE_URL;
     this.rateLimiter = new RateLimiter(parameters?.rateLimitSettings);
-    this.axiosInstance = axios.create({
-      auth: {
-        username: this.applicationId,
-        password: this.apiKey,
-      },
+    this.transport = new Transport({
+      baseURL: parameters?.baseUrl || DEFAULT_BASE_URL,
+      auth: { scheme: 'basic', applicationId: credentials.applicationId, apiKey: credentials.apiKey },
       headers: {
         'Content-Type': 'application/octet-stream',
         Accept: 'application/octet-stream',
-        'User-Agent': 'Travel Time Nodejs SDK',
       },
-      responseType: 'arraybuffer',
-      httpAgent: defaultHttpAgent,
-      httpsAgent: defaultHttpsAgent,
+      errorFormat: 'proto',
+      timeout: parameters?.timeout,
+      retry: { enabled: !this.rateLimiter.isEnabled(), ...parameters?.retry },
     });
 
     const root = this.readProtoFile();
@@ -124,8 +117,8 @@ export class TravelTimeProtoClient {
     return Math.round((targetPoint - sourcePoint) * 100000);
   }
 
-  private buildRequestUrl(uri: string, country: string, transportModeUrlName: string): string {
-    return `${uri}/${country}/time-filter/fast/${transportModeUrlName}`;
+  private buildRequestUrl(country: string, transportModeUrlName: string): string {
+    return `/${country}/time-filter/fast/${transportModeUrlName}`;
   }
 
   private buildDeltas(departure: Coords, destinations: Array<Coords>) {
@@ -205,7 +198,7 @@ export class TravelTimeProtoClient {
     destinationCoordinates,
     transportation,
     travelTime,
-  }: TimeFilterFastProtoRequest, uri: string, options?: ProtoRequestBuildOptions): TimeFilterProtoMessageWithUrl {
+  }: TimeFilterFastProtoRequest, options?: ProtoRequestBuildOptions): TimeFilterProtoMessageWithUrl {
     const transportationMode = this.extractTransportationMode(transportation);
     this.validateTransportationMode(transportationMode);
 
@@ -227,7 +220,7 @@ export class TravelTimeProtoClient {
       },
     };
 
-    const requestUrl = this.buildRequestUrl(uri, country, transportationConfig.urlName);
+    const requestUrl = this.buildRequestUrl(country, transportationConfig.urlName);
 
     return {
       requestMessage,
@@ -235,11 +228,11 @@ export class TravelTimeProtoClient {
     };
   }
 
-  private buildGeohashRequestUrl(uri: string, country: string, transportModeUrlName: string): string {
-    return `${uri}/${country}/geohash/fast/${transportModeUrlName}`;
+  private buildGeohashRequestUrl(country: string, transportModeUrlName: string): string {
+    return `/${country}/geohash/fast/${transportModeUrlName}`;
   }
 
-  private buildGeohashProtoRequest(request: GeohashFastProtoRequest, uri: string): { requestMessage: Record<string, any>, requestUrl: string } {
+  private buildGeohashProtoRequest(request: GeohashFastProtoRequest): { requestMessage: Record<string, any>, requestUrl: string } {
     const {
       country, departureLocation, arrivalLocation, transportation, travelTime, resolution, properties,
     } = request;
@@ -285,7 +278,7 @@ export class TravelTimeProtoClient {
       };
     }
 
-    const requestUrl = this.buildGeohashRequestUrl(uri, country, transportationConfig.urlName);
+    const requestUrl = this.buildGeohashRequestUrl(country, transportationConfig.urlName);
 
     return { requestMessage, requestUrl };
   }
@@ -307,25 +300,24 @@ export class TravelTimeProtoClient {
    * Decodes a proto response body. Decode failures mean the response was
    * received but could not be read, so they are not retryable.
    */
-  private decodeProtoResponse<T>(type: protobuf.Type, data: unknown): T {
+  private decodeProtoResponse<T>(type: protobuf.Type, data: Uint8Array): T {
     try {
-      return type.decode(data as Uint8Array).toJSON() as T;
+      return type.decode(data).toJSON() as T;
     } catch {
       throw new TravelTimeError({ description: 'Could not decode proto response', isRetryable: false });
     }
   }
 
   private async handleProtoFile(
-    uri: string,
     request: TimeFilterFastProtoRequest | TimeFilterFastProtoDistanceRequest,
     options?: ProtoRequestBuildOptions,
   ): Promise<TimeFilterFastProtoResponse> {
     try {
-      const { requestMessage, requestUrl } = this.buildProtoRequest(request, uri, options);
+      const { requestMessage, requestUrl } = this.buildProtoRequest(request, options);
       const message = this.TimeFilterFastRequest.create(requestMessage);
       const buffer = this.TimeFilterFastRequest.encode(message).finish();
 
-      const rq = () => this.axiosInstance.post(requestUrl, buffer);
+      const rq = () => this.transport.request(requestUrl, { method: 'POST', body: buffer });
 
       const promise = this.rateLimiter.isEnabled()
         ? new Promise<Awaited<ReturnType<typeof rq>>>((resolve) => {
@@ -333,23 +325,22 @@ export class TravelTimeProtoClient {
         })
         : rq();
 
-      const { data } = await promise;
-      return this.decodeProtoResponse<TimeFilterFastProtoResponse>(this.TimeFilterFastResponse, data);
+      const { body } = await promise;
+      return this.decodeProtoResponse<TimeFilterFastProtoResponse>(this.TimeFilterFastResponse, body);
     } catch (error) {
-      throw TravelTimeError.fromProtoError(error);
+      throw TravelTimeError.from(error);
     }
   }
 
   private async handleGeohashProtoFile(
-    uri: string,
     request: GeohashFastProtoRequest,
   ): Promise<GeohashFastProtoResponse> {
     try {
-      const { requestMessage, requestUrl } = this.buildGeohashProtoRequest(request, uri);
+      const { requestMessage, requestUrl } = this.buildGeohashProtoRequest(request);
       const message = this.GeohashFastRequest.create(requestMessage);
       const buffer = this.GeohashFastRequest.encode(message).finish();
 
-      const rq = () => this.axiosInstance.post(requestUrl, buffer);
+      const rq = () => this.transport.request(requestUrl, { method: 'POST', body: buffer });
 
       const promise = this.rateLimiter.isEnabled()
         ? new Promise<Awaited<ReturnType<typeof rq>>>((resolve) => {
@@ -357,35 +348,16 @@ export class TravelTimeProtoClient {
         })
         : rq();
 
-      const { data } = await promise;
-      return this.decodeProtoResponse<GeohashFastProtoResponse>(this.GeohashFastResponse, data);
+      const { body } = await promise;
+      return this.decodeProtoResponse<GeohashFastProtoResponse>(this.GeohashFastResponse, body);
     } catch (error) {
-      throw TravelTimeError.fromProtoError(error);
+      throw TravelTimeError.from(error);
     }
   }
 
-  timeFilterFast = async (request: TimeFilterFastProtoRequest) => this.handleProtoFile(this.baseURL, request);
+  timeFilterFast = async (request: TimeFilterFastProtoRequest) => this.handleProtoFile(request);
 
-  timeFilterFastDistance = async (request: TimeFilterFastProtoDistanceRequest) => this.handleProtoFile(this.baseURL, request, { useDistance: true });
+  timeFilterFastDistance = async (request: TimeFilterFastProtoDistanceRequest) => this.handleProtoFile(request, { useDistance: true });
 
-  geohashFast = async (request: GeohashFastProtoRequest) => this.handleGeohashProtoFile(this.baseURL, request);
-
-  setRateLimitSettings = (settings: Partial<RateLimitSettings>) => {
-    this.rateLimiter.setRateLimitSettings(settings);
-  };
-
-  getBaseURL = () => this.baseURL;
-
-  /**
-   *
-   * @param baseURL Set new base URL. Pass nothing to reset to default
-   */
-  setBaseURL = (baseURL = DEFAULT_BASE_URL) => {
-    this.baseURL = baseURL;
-  };
-
-  setCredentials = (credentials: Credentials) => {
-    this.apiKey = credentials.apiKey;
-    this.applicationId = credentials.applicationId;
-  };
+  geohashFast = async (request: GeohashFastProtoRequest) => this.handleGeohashProtoFile(request);
 }

--- a/src/client/protoClient.ts
+++ b/src/client/protoClient.ts
@@ -88,10 +88,8 @@ export class TravelTimeProtoClient {
     this.transport = new Transport({
       baseURL: parameters?.baseUrl || DEFAULT_BASE_URL,
       auth: { scheme: 'basic', applicationId: credentials.applicationId, apiKey: credentials.apiKey },
-      headers: {
-        'Content-Type': 'application/octet-stream',
-        Accept: 'application/octet-stream',
-      },
+      headers: { Accept: 'application/octet-stream' },
+      contentType: 'application/octet-stream',
       errorFormat: 'proto',
       timeout: parameters?.timeout,
       retry: { enabled: !this.rateLimiter.isEnabled(), ...parameters?.retry },

--- a/src/core/transport.ts
+++ b/src/core/transport.ts
@@ -32,6 +32,8 @@ export interface TransportOptions {
   auth: TransportAuth;
   /** Default headers, merged over the transport's standard headers. */
   headers?: Record<string, string>;
+  /** Content type sent with a request body. Default `'application/json'`. */
+  contentType?: string;
   /** How non-2xx responses carry API errors: a JSON body or `x-error-*` headers. Default `'json'`. */
   errorFormat?: 'json' | 'proto';
   /** Per-attempt timeout in milliseconds. Default `120000`. */
@@ -66,7 +68,8 @@ function joinUrl(baseURL: string, path: string): string {
 
 function buildHeaders(options: TransportOptions): Record<string, string> {
   const headers: Record<string, string> = {
-    'Content-Type': 'application/json',
+    Accept: 'application/json, text/plain, */*',
+    'Accept-Language': 'en',
     'User-Agent': `Travel Time Nodejs SDK ${sdkVersion}`,
     ...options.headers,
   };
@@ -99,6 +102,7 @@ function tryParseJson(body: Buffer): unknown {
 export class Transport {
   private baseURL: string;
   private headers: Record<string, string>;
+  private contentType: string;
   private errorFormat: 'json' | 'proto';
   private timeout: number;
   private retry: Required<TransportRetryOptions>;
@@ -106,6 +110,7 @@ export class Transport {
   constructor(options: TransportOptions) {
     this.baseURL = options.baseURL;
     this.headers = buildHeaders(options);
+    this.contentType = options.contentType ?? 'application/json';
     this.errorFormat = options.errorFormat ?? 'json';
     this.timeout = options.timeout ?? DEFAULT_TIMEOUT;
     this.retry = {
@@ -148,7 +153,12 @@ export class Transport {
       // Referenced at call time, not captured, so tests can stub the global.
       const response = await fetch(url, {
         method: options.method,
-        headers: { ...this.headers, ...options.headers },
+        // Content-Type describes a body, so it is only sent when there is one
+        headers: {
+          ...this.headers,
+          ...(options.body === undefined ? {} : { 'Content-Type': this.contentType }),
+          ...options.headers,
+        },
         body: options.body,
         signal: timeoutSignal,
       });

--- a/src/core/transport.ts
+++ b/src/core/transport.ts
@@ -1,0 +1,198 @@
+import { setTimeout as sleep } from 'node:timers/promises';
+import { TravelTimeError, TravelTimeNetworkError, TravelTimeValidationError } from '../error';
+
+const sdkVersion = require('../../package.json').version;
+
+const DEFAULT_TIMEOUT = 120_000;
+const DEFAULT_RETRY_MAX_RETRIES = 3;
+const DEFAULT_RETRY_BASE_DELAY = 1_000;
+const DEFAULT_RETRY_MAX_DELAY = 60_000;
+
+export interface TransportRetryOptions {
+  /** Whether requests rejected with HTTP 429 are retried. Default `true`. */
+  enabled?: boolean;
+  /** Maximum number of retries after the initial attempt. Default `3`. */
+  maxRetries?: number;
+  /** First backoff delay in milliseconds, doubled on every retry. Default `1000`. */
+  baseDelay?: number;
+  /** Upper bound in milliseconds for any single retry delay. Default `60000`. */
+  maxDelay?: number;
+}
+
+export type TransportAuth = {
+  /** `api-key` sends `X-Application-Id`/`X-Api-Key` headers, `basic` sends an `Authorization: Basic` header. */
+  scheme: 'api-key' | 'basic';
+  applicationId: string;
+  apiKey: string;
+};
+
+export interface TransportOptions {
+  /** Absolute base URL. */
+  baseURL: string;
+  auth: TransportAuth;
+  /** Default headers, merged over the transport's standard headers. */
+  headers?: Record<string, string>;
+  /** How non-2xx responses carry API errors: a JSON body or `x-error-*` headers. Default `'json'`. */
+  errorFormat?: 'json' | 'proto';
+  /** Per-attempt timeout in milliseconds. Default `120000`. */
+  timeout?: number;
+  retry?: TransportRetryOptions;
+}
+
+export interface TransportRequestOptions {
+  method: 'GET' | 'POST';
+  headers?: Record<string, string>;
+  query?: Record<string, unknown>;
+  body?: string | Uint8Array;
+}
+
+export interface TransportResponse {
+  status: number;
+  body: Buffer;
+}
+
+type AttemptOutcome =
+  | { ok: true; response: TransportResponse }
+  | { ok: false; error: TravelTimeError };
+
+/**
+ * Joins a base URL and a request path with exactly one slash, so a base URL
+ * that ends in a slash keeps working: `https://api.traveltimeapp.com/v4/`
+ * would otherwise produce `/v4//map-info`, which the API answers with a 404.
+ */
+function joinUrl(baseURL: string, path: string): string {
+  return `${baseURL.replace(/\/+$/, '')}/${path.replace(/^\/+/, '')}`;
+}
+
+function buildHeaders(options: TransportOptions): Record<string, string> {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    'User-Agent': `Travel Time Nodejs SDK ${sdkVersion}`,
+    ...options.headers,
+  };
+  const { auth } = options;
+  if (auth.scheme === 'basic') {
+    headers.Authorization = `Basic ${Buffer.from(`${auth.applicationId}:${auth.apiKey}`).toString('base64')}`;
+  } else {
+    headers['X-Application-Id'] = auth.applicationId;
+    headers['X-Api-Key'] = auth.apiKey;
+  }
+  return headers;
+}
+
+function tryParseJson(body: Buffer): unknown {
+  try {
+    return JSON.parse(body.toString('utf8'));
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Shared HTTP layer for both clients, built on the native `fetch`.
+ *
+ * - applies a per-attempt timeout
+ * - retries HTTP 429 with exponential backoff and jitter
+ * - maps every failure to a sanitized `TravelTimeError` subclass; raw
+ *   request/response objects (which carry credential headers) never escape
+ */
+export class Transport {
+  private baseURL: string;
+  private headers: Record<string, string>;
+  private errorFormat: 'json' | 'proto';
+  private timeout: number;
+  private retry: Required<TransportRetryOptions>;
+
+  constructor(options: TransportOptions) {
+    this.baseURL = options.baseURL;
+    this.headers = buildHeaders(options);
+    this.errorFormat = options.errorFormat ?? 'json';
+    this.timeout = options.timeout ?? DEFAULT_TIMEOUT;
+    this.retry = {
+      enabled: options.retry?.enabled ?? true,
+      maxRetries: options.retry?.maxRetries ?? DEFAULT_RETRY_MAX_RETRIES,
+      baseDelay: options.retry?.baseDelay ?? DEFAULT_RETRY_BASE_DELAY,
+      maxDelay: options.retry?.maxDelay ?? DEFAULT_RETRY_MAX_DELAY,
+    };
+    if (!Number.isFinite(this.timeout) || this.timeout <= 0) {
+      throw new TravelTimeValidationError('timeout must be a positive number of milliseconds');
+    }
+  }
+
+  async request(path: string, options: TransportRequestOptions): Promise<TransportResponse> {
+    const url = this.buildUrl(path, options.query);
+    const maxRetries = this.retry.enabled ? this.retry.maxRetries : 0;
+    for (let attempt = 0; ; attempt += 1) {
+      const outcome = await this.attempt(url, options);
+      if (outcome.ok) return outcome.response;
+      const shouldRetry = outcome.error.status === 429 && attempt < maxRetries;
+      if (!shouldRetry) throw outcome.error;
+      await this.waitBeforeRetry(this.retryDelay(attempt));
+    }
+  }
+
+  private buildUrl(path: string, query?: TransportRequestOptions['query']): string {
+    const url = joinUrl(this.baseURL, path);
+    if (!query) return url;
+    const params = new URLSearchParams();
+    Object.entries(query).forEach(([key, value]) => {
+      if (value !== undefined && value !== null) params.append(key, String(value));
+    });
+    const qs = params.toString();
+    return qs === '' ? url : `${url}?${qs}`;
+  }
+
+  private async attempt(url: string, options: TransportRequestOptions): Promise<AttemptOutcome> {
+    const timeoutSignal = AbortSignal.timeout(this.timeout);
+    try {
+      // Referenced at call time, not captured, so tests can stub the global.
+      const response = await fetch(url, {
+        method: options.method,
+        headers: { ...this.headers, ...options.headers },
+        body: options.body,
+        signal: timeoutSignal,
+      });
+      const body = Buffer.from(await response.arrayBuffer());
+      if (response.status >= 200 && response.status < 300) {
+        return { ok: true, response: { status: response.status, body } };
+      }
+      return { ok: false, error: this.errorFromResponse(response, body, url) };
+    } catch (error) {
+      return { ok: false, error: this.errorFromThrown(error, timeoutSignal, url) };
+    }
+  }
+
+  private errorFromResponse(response: Response, body: Buffer, url: string): TravelTimeError {
+    if (this.errorFormat === 'proto') {
+      return TravelTimeError.fromProtoResponse(response.status, response.headers, url);
+    }
+    return TravelTimeError.fromJsonResponse(response.status, tryParseJson(body), url);
+  }
+
+  /**
+   * Maps a failure thrown by `fetch` or by the body read. The guard for an
+   * already-mapped error must stay first: anything thrown from inside the
+   * request that happened to land after the timeout fired would otherwise be
+   * relabelled as a timeout.
+   */
+  private errorFromThrown(error: unknown, timeoutSignal: AbortSignal, url: string): TravelTimeError {
+    if (error instanceof TravelTimeError) return error;
+    if (timeoutSignal.aborted) {
+      return new TravelTimeNetworkError({
+        description: `Request timed out after ${this.timeout} ms`, code: 'ETIMEDOUT', url, isRetryable: true,
+      });
+    }
+    return TravelTimeNetworkError.from(error, url);
+  }
+
+  private retryDelay(attempt: number): number {
+    const { baseDelay, maxDelay } = this.retry;
+    const backoff = Math.min(baseDelay * 2 ** attempt, maxDelay);
+    // Equal jitter: uniform over [backoff/2, backoff), so concurrent retries spread out
+    return backoff / 2 + Math.random() * (backoff / 2);
+  }
+
+  private async waitBeforeRetry(delay: number): Promise<void> {
+    await sleep(delay);
+  }
+}

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,6 +1,3 @@
-/* eslint-disable max-classes-per-file, no-use-before-define */
-import axios from 'axios';
-
 /**
  * Shape of the TravelTime API JSON error response body.
  * https://docs.traveltime.com/api/reference/error-response
@@ -35,8 +32,8 @@ function isApiErrorPayload(payload: any): payload is TravelTimeApiErrorPayload {
 }
 
 /**
- * Reduces a request URL to origin + path. Strips the query string, the
- * fragment, and any userinfo a caller may have embedded in a custom base URL.
+ * Reduces a request URL to origin + path, dropping the query string and
+ * fragment so a recorded URL stays short and stable.
  */
 function sanitizeUrl(url: unknown): string | undefined {
   if (typeof url !== 'string') return undefined;
@@ -53,6 +50,21 @@ function parseNumericHeader(value: unknown): number | undefined {
   if (typeof value !== 'string' || value.trim() === '') return undefined;
   const parsed = Number(value);
   return Number.isNaN(parsed) ? undefined : parsed;
+}
+
+/**
+ * Extracts a low-level error code (`ENOTFOUND`, `ECONNREFUSED`, …) from the
+ * `cause` of a native fetch failure. Connection failures against a host with
+ * several addresses arrive as an `AggregateError`, so those are unwrapped.
+ */
+function extractCauseCode(cause: unknown): string | undefined {
+  if (typeof cause !== 'object' || cause === null) return undefined;
+  const { code } = cause as { code?: unknown };
+  if (typeof code === 'string') return code;
+  if (cause instanceof AggregateError) {
+    return cause.errors.map((inner) => extractCauseCode(inner)).find((c) => c !== undefined);
+  }
+  return undefined;
 }
 
 /**
@@ -109,49 +121,51 @@ export class TravelTimeError extends Error {
   }
 
   /**
-   * Maps a failure from a JSON API request to a `TravelTimeError`.
-   * Errors that are not TravelTime-shaped (timeouts, DNS failures,
-   * proxy errors, non-JSON 5xx pages) become `TravelTimeNetworkError`.
-   * Never returns the original error object.
+   * Maps a non-2xx JSON API response to a `TravelTimeError`. `body` is the
+   * parsed response body; bodies that are not TravelTime-shaped (non-JSON
+   * 5xx pages, proxy errors) become `TravelTimeNetworkError`.
    */
-  static fromJsonError(error: unknown): TravelTimeError {
-    if (error instanceof TravelTimeError) return error;
-    const response = (error as any)?.response;
-    const data = response?.data;
-    if (isApiErrorPayload(data)) {
+  static fromJsonResponse(status: number, body: unknown, url?: string): TravelTimeError {
+    if (isApiErrorPayload(body)) {
       return new TravelTimeError({
-        status: typeof response.status === 'number' ? response.status : data.http_status,
-        errorCode: data.error_code,
-        description: data.description,
-        documentationLink: data.documentation_link,
-        additionalInfo: data.additional_info,
+        status,
+        errorCode: body.error_code,
+        description: body.description,
+        documentationLink: body.documentation_link,
+        additionalInfo: body.additional_info,
       });
     }
-    return TravelTimeNetworkError.from(error);
+    return new TravelTimeNetworkError({ description: `Request failed with status code ${status}`, status, url });
   }
 
   /**
-   * Maps a failure from a proto API request to a `TravelTimeError`,
-   * reading the `x-error-code`, `x-error-message` and `x-error-details`
-   * response headers. Failures without those headers become
-   * `TravelTimeNetworkError`. Never returns the original error object.
+   * Maps a non-2xx proto API response to a `TravelTimeError`, reading the
+   * `x-error-code`, `x-error-message` and `x-error-details` response
+   * headers. Responses without those headers become `TravelTimeNetworkError`.
    */
-  static fromProtoError(error: unknown): TravelTimeError {
-    if (error instanceof TravelTimeError) return error;
-    if (axios.isAxiosError(error) && error.response) {
-      const { headers, status } = error.response;
-      const errorCode = headers?.['x-error-code'];
-      const errorMessage = headers?.['x-error-message'];
-      const errorDetails = headers?.['x-error-details'];
-      if (errorCode !== undefined || errorMessage !== undefined) {
-        return new TravelTimeError({
-          status,
-          errorCode: parseNumericHeader(errorCode),
-          description: typeof errorMessage === 'string' && errorMessage.length > 0 ? errorMessage : `Proto request failed with status code ${status}`,
-          details: typeof errorDetails === 'string' ? errorDetails : undefined,
-        });
-      }
+  static fromProtoResponse(status: number, headers: Headers, url?: string): TravelTimeError {
+    const errorCode = headers.get('x-error-code');
+    const errorMessage = headers.get('x-error-message');
+    const errorDetails = headers.get('x-error-details');
+    if (errorCode !== null || errorMessage !== null) {
+      return new TravelTimeError({
+        status,
+        errorCode: parseNumericHeader(errorCode),
+        description: errorMessage !== null && errorMessage.length > 0 ? errorMessage : `Proto request failed with status code ${status}`,
+        details: errorDetails ?? undefined,
+      });
     }
+    return new TravelTimeNetworkError({ description: `Proto request failed with status code ${status}`, status, url });
+  }
+
+  /**
+   * Last-resort wrapper for a thrown failure: an already-mapped error passes
+   * through, anything else is sanitized into a `TravelTimeNetworkError`. Never
+   * returns the original error object. Non-2xx responses do not throw under
+   * fetch — those are mapped by `fromJsonResponse` / `fromProtoResponse`.
+   */
+  static from(error: unknown): TravelTimeError {
+    if (error instanceof TravelTimeError) return error;
     return TravelTimeNetworkError.from(error);
   }
 }
@@ -180,7 +194,7 @@ export interface TravelTimeNetworkErrorParams {
  * error body. Holds only primitive, credential-free diagnostics.
  */
 export class TravelTimeNetworkError extends TravelTimeError {
-  /** Low-level error code, e.g. `ECONNABORTED` or `ENOTFOUND`. */
+  /** Low-level error code, e.g. `ETIMEDOUT` or `ENOTFOUND`. */
   readonly code?: string;
   /** Request path, without the query string. */
   readonly url?: string;
@@ -193,7 +207,9 @@ export class TravelTimeNetworkError extends TravelTimeError {
     });
     this.name = 'TravelTimeNetworkError';
     this.code = params.code;
-    this.url = params.url;
+    // Every URL recorded on an error goes through sanitizeUrl, so no call
+    // site can log a query string by accident
+    this.url = sanitizeUrl(params.url);
   }
 
   toJSON(): Record<string, any> {
@@ -205,20 +221,40 @@ export class TravelTimeNetworkError extends TravelTimeError {
    * copying only primitive diagnostics so that no headers, auth data, or
    * request/response objects can reach consumers.
    */
-  static from(error: unknown): TravelTimeNetworkError {
-    if (axios.isAxiosError(error)) {
-      return new TravelTimeNetworkError({
-        description: error.message || 'Request failed',
-        code: error.code,
-        status: error.response?.status,
-        url: sanitizeUrl(error.config?.url),
-      });
+  static from(error: unknown, url?: string): TravelTimeNetworkError {
+    if (typeof error === 'object' && error !== null) {
+      // Timeouts and aborts surface from fetch as DOMExceptions
+      const { name } = error as { name?: unknown };
+      if (name === 'TimeoutError') {
+        return new TravelTimeNetworkError({
+          description: 'Request timed out', code: 'ETIMEDOUT', url, isRetryable: true,
+        });
+      }
+      if (name === 'AbortError') {
+        return new TravelTimeNetworkError({
+          description: 'Request was aborted', code: 'ABORT_ERR', url, isRetryable: false,
+        });
+      }
     }
-    // Not an axios error, so no transport failure was observed — most likely a
-    // local encode/decode or programming error, which retrying cannot fix
     if (error instanceof Error) {
-      return new TravelTimeNetworkError({ description: error.message || error.name, isRetryable: false });
+      const { cause } = error as { cause?: unknown };
+      if (error instanceof TypeError && cause !== undefined) {
+        // A native fetch transport failure: the message is a terse
+        // 'fetch failed' and the useful detail lives on the cause. Copy only
+        // its message and code — never the cause object itself.
+        const code = extractCauseCode(cause);
+        const causeMessage = cause instanceof Error && cause.message !== '' ? cause.message : undefined;
+        return new TravelTimeNetworkError({
+          description: causeMessage ?? (code !== undefined ? `${error.message} (${code})` : error.message),
+          code,
+          url,
+          isRetryable: true,
+        });
+      }
+      // No transport failure was observed — most likely a local
+      // encode/decode or programming error, which retrying cannot fix
+      return new TravelTimeNetworkError({ description: error.message || error.name, url, isRetryable: false });
     }
-    return new TravelTimeNetworkError({ description: typeof error === 'string' ? error : 'Unknown request failure', isRetryable: false });
+    return new TravelTimeNetworkError({ description: typeof error === 'string' ? error : 'Unknown request failure', url, isRetryable: false });
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,3 +2,4 @@ export * from './types';
 export * from './error';
 export * from './client';
 export * from './utils';
+export type { TransportRetryOptions } from './core/transport';

--- a/tests/unit/error.test.ts
+++ b/tests/unit/error.test.ts
@@ -1,4 +1,6 @@
-import { describe, it, expect } from 'vitest';
+import {
+  describe, it, expect, vi, afterEach,
+} from 'vitest';
 import util from 'node:util';
 import {
   TravelTimeClient,
@@ -60,6 +62,10 @@ function expectNoSentinel(err: unknown) {
 }
 
 describe('error model', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   describe('credential leak regression', () => {
     it('should not leak credentials from a non-TravelTime-shaped HTTP failure (JSON response mapping)', () => {
       // fetch resolved with a 500 whose body is not a TravelTime payload
@@ -312,9 +318,8 @@ describe('error model', () => {
 
     it('should not mark an undecodable proto response as retryable', async () => {
       // A response arrived, so the failure is permanent — retrying cannot help
-      const client = new TravelTimeProtoClient({ apiKey: 'key', applicationId: 'app' }, {
-        fetch: async () => new Response(Buffer.from([0xff, 0xff, 0xff, 0xff]), { status: 200 }),
-      });
+      vi.stubGlobal('fetch', async () => new Response(Buffer.from([0xff, 0xff, 0xff, 0xff]), { status: 200 }));
+      const client = new TravelTimeProtoClient({ apiKey: 'key', applicationId: 'app' });
 
       try {
         await client.timeFilterFast({

--- a/tests/unit/error.test.ts
+++ b/tests/unit/error.test.ts
@@ -9,37 +9,35 @@ import {
 } from '../../src';
 
 const SENTINEL = 'SENTINEL-API-KEY-b8f2c611';
+const REQUEST_URL = 'https://api.traveltimeapp.com/v4/time-map';
 
-function makeAxiosError(overrides: Record<string, any> = {}) {
-  const config = {
-    url: '/time-map',
-    method: 'post',
-    baseURL: 'https://api.traveltimeapp.com/v4',
-    headers: {
-      'Content-Type': 'application/json',
-      'X-Api-Key': SENTINEL,
-      Authorization: `Basic ${SENTINEL}`,
+/**
+ * A native fetch transport failure: a terse TypeError whose useful detail is
+ * on `cause`. The cause carries the sentinel on properties a sloppy mapping
+ * might copy wholesale (undici attaches connect options to some causes).
+ */
+function makeFetchFailure(overrides: { message?: string; code?: string; causeMessage?: string } = {}) {
+  const cause = Object.assign(new Error(overrides.causeMessage ?? 'getaddrinfo ENOTFOUND api.traveltimeapp.com'), {
+    code: overrides.code ?? 'ENOTFOUND',
+    syscall: 'getaddrinfo',
+    hostname: 'api.traveltimeapp.com',
+    localAddress: SENTINEL,
+    options: {
+      headers: {
+        'X-Api-Key': SENTINEL,
+        Authorization: `Basic ${SENTINEL}`,
+      },
     },
-    auth: { username: 'app-id', password: SENTINEL },
-  };
-  const request = { _header: `POST /time-map HTTP/1.1\r\nX-Api-Key: ${SENTINEL}\r\n` };
-  const error: any = new Error('Request failed with status code 500');
-  error.name = 'AxiosError';
-  error.isAxiosError = true;
-  error.code = 'ERR_BAD_RESPONSE';
-  error.config = config;
-  error.request = request;
-  error.response = {
-    status: 500,
-    statusText: 'Internal Server Error',
-    headers: {},
-    config,
-    request,
-    data: '<html>Internal Server Error</html>',
-  };
-  Object.assign(error, overrides);
-  return error;
+  });
+  return new TypeError(overrides.message ?? 'fetch failed', { cause });
 }
+
+/** Response headers as a server (or proxy) could echo them, sentinel included. */
+const makeResponseHeaders = (extra: Record<string, string> = {}) => new Headers({
+  'x-echoed-api-key': SENTINEL,
+  via: `proxy auth=${SENTINEL}`,
+  ...extra,
+});
 
 function walkEnumerable(value: unknown, visit: (str: string) => void, seen = new Set<object>()) {
   if (typeof value === 'string') {
@@ -61,58 +59,49 @@ function expectNoSentinel(err: unknown) {
   walkEnumerable(err, (str) => expect(str).not.toContain(SENTINEL));
 }
 
-const apiErrorResponse = (status: number, data: Record<string, unknown>) => ({
-  response: { ...makeAxiosError().response, status, data },
-});
-
-const protoErrorResponse = (headers: Record<string, string>) => ({
-  response: { ...makeAxiosError().response, status: 400, headers },
-});
-
 describe('error model', () => {
   describe('credential leak regression', () => {
-    it('should not leak credentials from a non-TravelTime-shaped HTTP failure (JSON client mapping)', () => {
-      const err = TravelTimeError.fromJsonError(makeAxiosError());
+    it('should not leak credentials from a non-TravelTime-shaped HTTP failure (JSON response mapping)', () => {
+      // fetch resolved with a 500 whose body is not a TravelTime payload
+      const err = TravelTimeError.fromJsonResponse(500, '<html>Internal Server Error</html>', REQUEST_URL);
       expect(err).toBeInstanceOf(TravelTimeNetworkError);
+      expect(err.status).toBe(500);
       expectNoSentinel(err);
     });
 
     it('should not leak credentials from a TravelTime-shaped API error', () => {
-      const err = TravelTimeError.fromJsonError(makeAxiosError(apiErrorResponse(422, {
+      const err = TravelTimeError.fromJsonResponse(422, {
         http_status: 422,
         error_code: 10,
         description: 'Invalid request',
         documentation_link: 'https://docs.traveltime.com',
         additional_info: { travel_time: ['out of range'] },
-      })));
+      }, REQUEST_URL);
       expect(err).toBeInstanceOf(TravelTimeError);
       expectNoSentinel(err);
     });
 
     it('should not leak credentials from a proto error with x-error headers', () => {
-      const err = TravelTimeError.fromProtoError(makeAxiosError(protoErrorResponse({
+      const err = TravelTimeError.fromProtoResponse(400, makeResponseHeaders({
         'x-error-code': '4',
         'x-error-message': 'Invalid country',
         'x-error-details': 'country not supported',
-      })));
+      }), REQUEST_URL);
       expect(err).toBeInstanceOf(TravelTimeError);
       expectNoSentinel(err);
     });
 
     it('should not leak credentials from a proto failure without x-error headers', () => {
-      const err = TravelTimeError.fromProtoError(makeAxiosError());
+      const err = TravelTimeError.fromProtoResponse(500, makeResponseHeaders(), REQUEST_URL);
       expect(err).toBeInstanceOf(TravelTimeNetworkError);
       expect(err.status).toBe(500);
       expectNoSentinel(err);
     });
 
     it('should not leak credentials from a transport failure with no response', () => {
-      const err = TravelTimeError.fromJsonError(makeAxiosError({
-        message: 'timeout of 1000ms exceeded',
-        code: 'ECONNABORTED',
-        response: undefined,
-      }));
+      const err = TravelTimeError.from(makeFetchFailure());
       expect(err).toBeInstanceOf(TravelTimeNetworkError);
+      expect((err as TravelTimeNetworkError).code).toBe('ENOTFOUND');
       expectNoSentinel(err);
     });
 
@@ -126,32 +115,17 @@ describe('error model', () => {
         expectNoSentinel(error);
       }
     });
-
-    it('should strip the query string, fragment and any userinfo from the recorded url', () => {
-      const relative = TravelTimeNetworkError.from(makeAxiosError({
-        config: { url: '/time-map?key=value#frag' },
-        response: undefined,
-      }));
-      expect(relative.url).toBe('/time-map');
-
-      const absolute = TravelTimeNetworkError.from(makeAxiosError({
-        config: { url: `https://app-id:${SENTINEL}@proxy.internal/api/v3/time-filter/fast/uk` },
-        response: undefined,
-      }));
-      expect(absolute.url).toBe('https://proxy.internal/api/v3/time-filter/fast/uk');
-      expectNoSentinel(absolute);
-    });
   });
 
   describe('JSON error mapping', () => {
     it('should map API error body fields to camelCase fields', () => {
-      const err = TravelTimeError.fromJsonError(makeAxiosError(apiErrorResponse(422, {
+      const err = TravelTimeError.fromJsonResponse(422, {
         http_status: 422,
         error_code: 10,
         description: 'Invalid request',
         documentation_link: 'https://docs.traveltime.com',
         additional_info: { travel_time: ['out of range'] },
-      })));
+      });
 
       expect(err.status).toBe(422);
       expect(err.errorCode).toBe(10);
@@ -162,9 +136,9 @@ describe('error model', () => {
     });
 
     it('should map a body with error_code 0 as a TravelTime API error, not a network error', () => {
-      const err = TravelTimeError.fromJsonError(makeAxiosError(apiErrorResponse(500, {
+      const err = TravelTimeError.fromJsonResponse(500, {
         http_status: 500, error_code: 0, description: 'Internal error', documentation_link: '', additional_info: {},
-      })));
+      });
 
       expect(err).not.toBeInstanceOf(TravelTimeNetworkError);
       expect(err.errorCode).toBe(0);
@@ -173,18 +147,17 @@ describe('error model', () => {
 
     it('should return an already-mapped TravelTimeError as-is', () => {
       const original = new TravelTimeValidationError('bad input');
-      expect(TravelTimeError.fromJsonError(original)).toBe(original);
-      expect(TravelTimeError.fromProtoError(original)).toBe(original);
+      expect(TravelTimeError.from(original)).toBe(original);
     });
   });
 
   describe('proto error mapping', () => {
     it('should map x-error headers onto error fields', () => {
-      const err = TravelTimeError.fromProtoError(makeAxiosError(protoErrorResponse({
+      const err = TravelTimeError.fromProtoResponse(400, new Headers({
         'x-error-code': '4',
         'x-error-message': 'Invalid country',
         'x-error-details': 'country not supported',
-      })));
+      }));
 
       expect(err.status).toBe(400);
       expect(err.errorCode).toBe(4);
@@ -193,17 +166,48 @@ describe('error model', () => {
     });
 
     it('should not produce NaN when x-error-code is absent or not numeric', () => {
-      const missingCode = TravelTimeError.fromProtoError(makeAxiosError(protoErrorResponse({
+      const missingCode = TravelTimeError.fromProtoResponse(400, new Headers({
         'x-error-message': 'Invalid country',
-      })));
+      }));
       expect(missingCode.errorCode).toBeUndefined();
       expect(missingCode.description).toBe('Invalid country');
 
-      const badCode = TravelTimeError.fromProtoError(makeAxiosError(protoErrorResponse({
+      const badCode = TravelTimeError.fromProtoResponse(400, new Headers({
         'x-error-code': 'not-a-number',
         'x-error-message': 'Invalid country',
-      })));
+      }));
       expect(badCode.errorCode).toBeUndefined();
+    });
+  });
+
+  describe('thrown failure mapping', () => {
+    it('should surface the useful detail from a fetch failure cause', () => {
+      const err = TravelTimeNetworkError.from(makeFetchFailure());
+      expect(err.code).toBe('ENOTFOUND');
+      expect(err.description).toBe('getaddrinfo ENOTFOUND api.traveltimeapp.com');
+    });
+
+    it('should unwrap an AggregateError cause to find the code', () => {
+      const cause = new AggregateError([
+        Object.assign(new Error('connect ECONNREFUSED 127.0.0.1:443'), { code: 'ECONNREFUSED' }),
+        Object.assign(new Error('connect ECONNREFUSED ::1:443'), { code: 'ECONNREFUSED' }),
+      ], '');
+      const err = TravelTimeNetworkError.from(new TypeError('fetch failed', { cause }));
+      expect(err.code).toBe('ECONNREFUSED');
+      expect(err.isRetryable).toBe(true);
+    });
+
+    it('should map a timeout DOMException as a retryable timeout', () => {
+      const err = TravelTimeNetworkError.from(new DOMException('The operation was aborted due to timeout', 'TimeoutError'));
+      expect(err.code).toBe('ETIMEDOUT');
+      expect(err.isRetryable).toBe(true);
+    });
+
+    it('should map an abort DOMException as a non-retryable abort, distinct from a timeout', () => {
+      const err = TravelTimeNetworkError.from(new DOMException('This operation was aborted', 'AbortError'));
+      expect(err.code).toBe('ABORT_ERR');
+      expect(err.code).not.toBe('ETIMEDOUT');
+      expect(err.isRetryable).toBe(false);
     });
   });
 
@@ -211,24 +215,21 @@ describe('error model', () => {
     expect(TravelTimeError.isTravelTimeError(new TravelTimeValidationError('bad'))).toBe(true);
     expect(TravelTimeError.isTravelTimeError(TravelTimeNetworkError.from(new Error('boom')))).toBe(true);
     expect(TravelTimeError.isTravelTimeError(new Error('boom'))).toBe(false);
-    // the pre-v8 guard matched this payload shape rather than a caught error
+    // a raw API payload is not a caught error, so it must not narrow
     expect(TravelTimeError.isTravelTimeError({ error_code: 10, description: 'payload, not an error' })).toBe(false);
     expect(TravelTimeError.isTravelTimeError(undefined)).toBe(false);
   });
 
   it('should compute isRetryable from the kind of failure', () => {
-    const notFound = makeAxiosError({ response: { ...makeAxiosError().response, status: 404 } });
     const cases: Array<[string, TravelTimeError, boolean]> = [
       ['429', new TravelTimeError({ description: 'too many requests', status: 429 }), true],
-      ['5xx', TravelTimeError.fromJsonError(makeAxiosError()), true],
+      ['5xx', TravelTimeError.fromJsonResponse(500, '<html>Internal Server Error</html>'), true],
       ['other 4xx', new TravelTimeError({ description: 'unprocessable', status: 422 }), false],
-      ['4xx without a TravelTime body', TravelTimeNetworkError.from(notFound), false],
-      ['transport failure with no status', TravelTimeError.fromJsonError(makeAxiosError({
-        code: 'ENOTFOUND', response: undefined,
-      })), true],
+      ['4xx without a TravelTime body', TravelTimeError.fromJsonResponse(404, undefined), false],
+      ['transport failure with no status', TravelTimeError.from(makeFetchFailure()), true],
       ['validation failure', new TravelTimeValidationError('bad input'), false],
       // no transport failure was observed, so retrying cannot help
-      ['non-axios failure', TravelTimeNetworkError.from(new TypeError('boom')), false],
+      ['non-fetch failure', TravelTimeNetworkError.from(new TypeError('boom')), false],
     ];
 
     cases.forEach(([label, error, expected]) => {
@@ -310,9 +311,10 @@ describe('error model', () => {
     });
 
     it('should not mark an undecodable proto response as retryable', async () => {
-      const client = new TravelTimeProtoClient({ apiKey: 'key', applicationId: 'app' });
       // A response arrived, so the failure is permanent — retrying cannot help
-      (client as any).axiosInstance.post = async () => ({ data: Buffer.from([0xff, 0xff, 0xff, 0xff]) });
+      const client = new TravelTimeProtoClient({ apiKey: 'key', applicationId: 'app' }, {
+        fetch: async () => new Response(Buffer.from([0xff, 0xff, 0xff, 0xff]), { status: 200 }),
+      });
 
       try {
         await client.timeFilterFast({

--- a/tests/unit/transport.test.ts
+++ b/tests/unit/transport.test.ts
@@ -81,6 +81,38 @@ describe('transport', () => {
       expect(calls[0].init.headers['X-Application-Id']).toBe('app-id');
       expect(calls[0].init.headers['X-Api-Key']).toBe('test-key');
       expect(calls[0].init.headers['User-Agent']).toMatch(/^Travel Time Nodejs SDK \d+\.\d+\.\d+/);
+      expect(calls[0].init.headers.Accept).toBe('application/json, text/plain, */*');
+    });
+
+    it('should not send Content-Type on a request without a body', async () => {
+      const { calls, fn } = recordingFetch(jsonResponse(200, {}));
+      await makeTransport(fn).request('/geocoding/search', { method: 'GET', query: { query: 'London' } });
+
+      expect(calls[0].init.headers['Content-Type']).toBeUndefined();
+      expect(calls[0].init.headers.Accept).toBe('application/json, text/plain, */*');
+    });
+
+    it('should send a valid default Accept-Language that a caller can override', async () => {
+      const { calls, fn } = recordingFetch(jsonResponse(200, {}), jsonResponse(200, {}));
+      const transport = makeTransport(fn);
+
+      await transport.request('/geocoding/search', { method: 'GET', query: { query: 'Munich' } });
+      expect(calls[0].init.headers['Accept-Language']).toBe('en');
+
+      await transport.request('/geocoding/search', {
+        method: 'GET',
+        query: { query: 'Munich' },
+        headers: { 'Accept-Language': 'de' },
+      });
+      expect(calls[1].init.headers['Accept-Language']).toBe('de');
+    });
+
+    it('should send the configured content type with a body', async () => {
+      const { calls, fn } = recordingFetch(jsonResponse(200, {}));
+      await makeTransport(fn, { contentType: 'application/octet-stream' })
+        .request('/uk/time-filter/fast/driving', { method: 'POST', body: new Uint8Array([1, 2]) });
+
+      expect(calls[0].init.headers['Content-Type']).toBe('application/octet-stream');
     });
 
     it('should send HTTP Basic credentials for the basic auth scheme', async () => {

--- a/tests/unit/transport.test.ts
+++ b/tests/unit/transport.test.ts
@@ -8,7 +8,6 @@ import {
   TravelTimeProtoClient,
   TravelTimeError,
   TravelTimeNetworkError,
-  TravelTimeValidationError,
 } from '../../src';
 
 const SENTINEL = 'SENTINEL-API-KEY-b8f2c611';

--- a/tests/unit/transport.test.ts
+++ b/tests/unit/transport.test.ts
@@ -1,0 +1,387 @@
+import {
+  describe, it, expect, vi, afterEach,
+} from 'vitest';
+import util from 'node:util';
+import { Transport, TransportOptions } from '../../src/core/transport';
+import {
+  TravelTimeClient,
+  TravelTimeProtoClient,
+  TravelTimeError,
+  TravelTimeNetworkError,
+  TravelTimeValidationError,
+} from '../../src';
+
+const SENTINEL = 'SENTINEL-API-KEY-b8f2c611';
+
+/** The transport reads the global `fetch` at call time, so tests stub it. */
+type FakeFetch = (url: string, init: RequestInit) => Promise<Response>;
+const stubFetch = (fn: FakeFetch) => vi.stubGlobal('fetch', fn);
+
+function walkEnumerable(value: unknown, visit: (str: string) => void, seen = new Set<object>()) {
+  if (typeof value === 'string') {
+    visit(value);
+    return;
+  }
+  if (typeof value !== 'object' || value === null || seen.has(value)) return;
+  seen.add(value);
+  Object.getOwnPropertyNames(value).forEach((key) => {
+    walkEnumerable((value as Record<string, unknown>)[key], visit, seen);
+  });
+}
+
+function expectNoSentinel(err: unknown) {
+  expect(JSON.stringify(err)).not.toContain(SENTINEL);
+  expect((err as Error).stack ?? '').not.toContain(SENTINEL);
+  expect(util.inspect(err, { depth: null })).not.toContain(SENTINEL);
+  walkEnumerable(err, (str) => expect(str).not.toContain(SENTINEL));
+}
+
+/** The transport always sends a plain header record, so recorded calls can be read as one. */
+type RecordedCall = { url: string; init: RequestInit & { headers: Record<string, string> } };
+
+/** A fake fetch that records calls and replays the given responses in order, repeating the last one. */
+function recordingFetch(...responses: Array<() => Response | Promise<Response>>) {
+  const calls: RecordedCall[] = [];
+  const fn = async (url: string, init: RequestInit) => {
+    calls.push({ url, init: init as RecordedCall['init'] });
+    return responses[Math.min(calls.length - 1, responses.length - 1)]();
+  };
+  return { calls, fn };
+}
+
+const jsonResponse = (status: number, body: unknown, headers: Record<string, string> = {}) => () => new Response(JSON.stringify(body), { status, headers });
+
+/** A fetch that never settles until its signal aborts, like a hung connection. */
+const hangingFetch = (url: string, init: RequestInit) => new Promise<Response>((resolve, reject) => {
+  init.signal?.addEventListener('abort', () => reject(init.signal?.reason), { once: true });
+});
+
+const makeTransport = (fetchFn: FakeFetch, overrides: Partial<TransportOptions> = {}) => {
+  stubFetch(fetchFn);
+  return new Transport({
+    baseURL: 'https://api.example.com/v4',
+    auth: { scheme: 'api-key', applicationId: 'app-id', apiKey: 'test-key' },
+    ...overrides,
+  });
+};
+
+describe('transport', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe('standard headers', () => {
+    it('should send Content-Type, credential headers and a versioned User-Agent', async () => {
+      const { calls, fn } = recordingFetch(jsonResponse(200, {}));
+      await makeTransport(fn).request('/time-map', { method: 'POST', body: '{}' });
+
+      expect(calls).toHaveLength(1);
+      expect(calls[0].url).toBe('https://api.example.com/v4/time-map');
+      expect(calls[0].init.headers['Content-Type']).toBe('application/json');
+      expect(calls[0].init.headers['X-Application-Id']).toBe('app-id');
+      expect(calls[0].init.headers['X-Api-Key']).toBe('test-key');
+      expect(calls[0].init.headers['User-Agent']).toMatch(/^Travel Time Nodejs SDK \d+\.\d+\.\d+/);
+    });
+
+    it('should send HTTP Basic credentials for the basic auth scheme', async () => {
+      const { calls, fn } = recordingFetch(jsonResponse(200, {}));
+      await makeTransport(fn, {
+        auth: { scheme: 'basic', applicationId: 'app-id', apiKey: 'test-key' },
+      }).request('/uk/time-filter/fast/driving', { method: 'POST', body: '{}' });
+
+      expect(calls[0].init.headers.Authorization).toBe(`Basic ${Buffer.from('app-id:test-key').toString('base64')}`);
+      expect(calls[0].init.headers['X-Api-Key']).toBeUndefined();
+    });
+
+    it('should let per-request headers override the defaults', async () => {
+      const { calls, fn } = recordingFetch(jsonResponse(200, {}));
+      await makeTransport(fn).request('/time-map', { method: 'POST', body: '{}', headers: { Accept: 'application/geo+json' } });
+
+      expect(calls[0].init.headers.Accept).toBe('application/geo+json');
+      expect(calls[0].init.headers['X-Api-Key']).toBe('test-key');
+    });
+
+    it('should serialize query parameters, skipping undefined values', async () => {
+      const { calls, fn } = recordingFetch(jsonResponse(200, {}));
+      await makeTransport(fn).request('/geocoding/search', {
+        method: 'GET',
+        query: { query: 'Parnidžio kopa', limit: 5, bounds: undefined },
+      });
+
+      expect(calls[0].url).toBe(`https://api.example.com/v4/geocoding/search?query=${encodeURIComponent('Parnidžio kopa').replace(/%20/g, '+')}&limit=5`);
+    });
+  });
+
+  describe('base URL handling', () => {
+    // a baseURL ending in a slash must keep working, or it silently 404s
+    it.each([
+      ['https://api.example.com/v4', '/time-map'],
+      ['https://api.example.com/v4/', '/time-map'],
+      ['https://api.example.com/v4///', '/time-map'],
+      ['https://api.example.com/v4', 'time-map'],
+      ['https://api.example.com/v4/', '//time-map'],
+    ])('should join base %j and path %j with a single slash', async (baseURL, path) => {
+      const { calls, fn } = recordingFetch(jsonResponse(200, {}));
+      await makeTransport(fn, { baseURL }).request(path, { method: 'POST', body: '{}' });
+      expect(calls[0].url).toBe('https://api.example.com/v4/time-map');
+    });
+
+    it('should accept an http base URL, e.g. a local mock server or proxy', async () => {
+      const { calls, fn } = recordingFetch(jsonResponse(200, {}));
+      await makeTransport(fn, { baseURL: 'http://localhost:8080' }).request('/time-map', { method: 'POST', body: '{}' });
+      expect(calls[0].url).toBe('http://localhost:8080/time-map');
+    });
+  });
+
+  describe('non-2xx mapping', () => {
+    it('should map a TravelTime-shaped JSON error body onto TravelTimeError', async () => {
+      const { fn } = recordingFetch(jsonResponse(422, {
+        http_status: 422, error_code: 10, description: 'Invalid request', documentation_link: 'https://docs.traveltime.com',
+      }));
+
+      const err = await makeTransport(fn).request('/time-map', { method: 'POST', body: '{}' }).catch((e) => e);
+      expect(err).toBeInstanceOf(TravelTimeError);
+      expect(err).not.toBeInstanceOf(TravelTimeNetworkError);
+      expect(err.status).toBe(422);
+      expect(err.errorCode).toBe(10);
+      expect(err.isRetryable).toBe(false);
+    });
+
+    it('should map a non-TravelTime-shaped body onto TravelTimeNetworkError with the status', async () => {
+      const { fn } = recordingFetch(() => new Response('<html>Bad Gateway</html>', { status: 502 }));
+
+      const err = await makeTransport(fn).request('/time-map', { method: 'POST', body: '{}' }).catch((e) => e);
+      expect(err).toBeInstanceOf(TravelTimeNetworkError);
+      expect(err.status).toBe(502);
+      expect(err.isRetryable).toBe(true);
+      expect(err.url).toBe('https://api.example.com/v4/time-map');
+    });
+
+    it('should map proto x-error headers onto TravelTimeError', async () => {
+      const { fn } = recordingFetch(() => new Response(null, {
+        status: 400,
+        headers: { 'x-error-code': '4', 'x-error-message': 'Invalid country', 'x-error-details': 'country not supported' },
+      }));
+
+      const err = await makeTransport(fn, { errorFormat: 'proto' }).request('/uk/time-filter/fast/driving', { method: 'POST' }).catch((e) => e);
+      expect(err).toBeInstanceOf(TravelTimeError);
+      expect(err).not.toBeInstanceOf(TravelTimeNetworkError);
+      expect(err.status).toBe(400);
+      expect(err.errorCode).toBe(4);
+      expect(err.description).toBe('Invalid country');
+      expect(err.details).toBe('country not supported');
+    });
+
+    it('should map a proto response without x-error headers onto TravelTimeNetworkError', async () => {
+      const { fn } = recordingFetch(() => new Response(null, { status: 401 }));
+
+      const err = await makeTransport(fn, { errorFormat: 'proto' }).request('/uk/time-filter/fast/driving', { method: 'POST' }).catch((e) => e);
+      expect(err).toBeInstanceOf(TravelTimeNetworkError);
+      expect(err.status).toBe(401);
+      expect(err.isRetryable).toBe(false);
+    });
+  });
+
+  describe('timeout', () => {
+    it('should time out a hung request with a retryable timeout error', async () => {
+      const err = await makeTransport(hangingFetch, { timeout: 30, retry: { enabled: false } })
+        .request('/time-map', { method: 'POST', body: '{}' })
+        .catch((e) => e);
+
+      expect(err).toBeInstanceOf(TravelTimeNetworkError);
+      expect(err.code).toBe('ETIMEDOUT');
+      expect(err.isRetryable).toBe(true);
+    });
+
+    it('should apply the timeout per attempt rather than once for the whole retry sequence', async () => {
+      const { calls, fn } = recordingFetch(
+        jsonResponse(429, { error_code: 5, description: 'Too many requests' }),
+        jsonResponse(200, { ok: true }),
+      );
+
+      const response = await makeTransport(fn, { timeout: 5_000, retry: { baseDelay: 10, maxDelay: 10 } })
+        .request('/time-map', { method: 'POST', body: '{}' });
+
+      expect(calls).toHaveLength(2);
+      expect(response.status).toBe(200);
+    });
+  });
+
+  describe('429 retry', () => {
+    it('should retry a 429 and succeed', async () => {
+      const { calls, fn } = recordingFetch(
+        jsonResponse(429, { error_code: 5, description: 'Too many requests' }),
+        jsonResponse(200, { ok: true }),
+      );
+
+      const response = await makeTransport(fn, { retry: { baseDelay: 10, maxDelay: 10 } })
+        .request('/time-map', { method: 'POST', body: '{}' });
+      expect(calls).toHaveLength(2);
+      expect(response.status).toBe(200);
+    });
+
+    it('should back off before retrying rather than firing straight away', async () => {
+      const { calls, fn } = recordingFetch(
+        jsonResponse(429, { error_code: 5, description: 'Too many requests' }),
+        jsonResponse(200, { ok: true }),
+      );
+
+      const started = Date.now();
+      await makeTransport(fn, { retry: { maxRetries: 1, baseDelay: 300, maxDelay: 300 } })
+        .request('/time-map', { method: 'POST', body: '{}' });
+
+      expect(calls).toHaveLength(2);
+      // the first backoff lands in the jitter band [150, 300)
+      expect(Date.now() - started).toBeGreaterThanOrEqual(140);
+    });
+
+    it('should cap the backoff at maxDelay', async () => {
+      const { calls, fn } = recordingFetch(
+        jsonResponse(429, { error_code: 5, description: 'Too many requests' }),
+        jsonResponse(200, { ok: true }),
+      );
+
+      const started = Date.now();
+      await makeTransport(fn, { retry: { baseDelay: 60_000, maxDelay: 5 } }).request('/time-map', { method: 'POST', body: '{}' });
+      expect(calls).toHaveLength(2);
+      expect(Date.now() - started).toBeLessThan(1000);
+    });
+
+    it('should exhaust retries and then throw the mapped 429', async () => {
+      const { calls, fn } = recordingFetch(
+        jsonResponse(429, { error_code: 5, description: 'Too many requests' }),
+      );
+
+      const err = await makeTransport(fn, { retry: { maxRetries: 2, baseDelay: 1, maxDelay: 4 } })
+        .request('/time-map', { method: 'POST', body: '{}' })
+        .catch((e) => e);
+
+      expect(calls).toHaveLength(3);
+      expect(err).toBeInstanceOf(TravelTimeError);
+      expect(err.status).toBe(429);
+      expect(err.errorCode).toBe(5);
+      expect(err.isRetryable).toBe(true);
+    });
+
+    it('should not retry when retry is disabled', async () => {
+      const { calls, fn } = recordingFetch(jsonResponse(429, { error_code: 5, description: 'Too many requests' }));
+
+      const err = await makeTransport(fn, { retry: { enabled: false } }).request('/time-map', { method: 'POST', body: '{}' }).catch((e) => e);
+      expect(calls).toHaveLength(1);
+      expect(err.status).toBe(429);
+    });
+
+    it('should not retry non-429 failures', async () => {
+      const { calls, fn } = recordingFetch(() => new Response('oops', { status: 503 }));
+
+      await makeTransport(fn).request('/time-map', { method: 'POST', body: '{}' }).catch(() => undefined);
+      expect(calls).toHaveLength(1);
+    });
+  });
+
+  describe('clients over the transport', () => {
+    it('should parse a JSON API response', async () => {
+      const { calls, fn } = recordingFetch(jsonResponse(200, { map_info: [] }));
+      stubFetch(fn);
+      const client = new TravelTimeClient({ apiKey: 'test-key', applicationId: 'app-id' });
+
+      await expect(client.mapInfo()).resolves.toEqual({ map_info: [] });
+      expect(calls[0].url).toBe('https://api.traveltimeapp.com/v4/map-info');
+      expect(calls[0].init.method).toBe('GET');
+    });
+
+    it('should keep the rate limiter 429 retry path working from the error status', async () => {
+      const { calls, fn } = recordingFetch(
+        jsonResponse(429, { error_code: 5, description: 'Too many requests' }),
+        jsonResponse(429, { error_code: 5, description: 'Too many requests' }),
+        jsonResponse(200, { type: 'FeatureCollection', features: [] }),
+      );
+      stubFetch(fn);
+      const client = new TravelTimeClient({ apiKey: 'test-key', applicationId: 'app-id' }, {
+        rateLimitSettings: { enabled: true, retryCount: 3, timeBetweenRetries: 1 },
+      });
+
+      await expect(client.geocoding('London')).resolves.toEqual({ type: 'FeatureCollection', features: [] });
+      // the transport's own retry is off while the rate limiter drives retries
+      expect(calls).toHaveLength(3);
+    });
+
+    it('should build the proto request against the transport with Basic auth', async () => {
+      const { calls, fn } = recordingFetch(() => new Response(new Uint8Array(0), { status: 200 }));
+      stubFetch(fn);
+      const client = new TravelTimeProtoClient({ apiKey: 'test-key', applicationId: 'app-id' });
+
+      await expect(client.timeFilterFast({
+        country: 'uk',
+        departureLocation: { lat: 51.5, lng: -0.1 },
+        destinationCoordinates: [{ lat: 51.6, lng: -0.2 }],
+        transportation: 'driving',
+        travelTime: 3600,
+      })).resolves.toBeDefined();
+
+      expect(calls[0].url).toBe('https://proto.api.traveltimeapp.com/api/v3/uk/time-filter/fast/driving');
+      expect(calls[0].init.headers.Authorization).toBe(`Basic ${Buffer.from('app-id:test-key').toString('base64')}`);
+      expect(calls[0].init.headers['Content-Type']).toBe('application/octet-stream');
+      expect(calls[0].init.body).toBeInstanceOf(Uint8Array);
+    });
+
+    describe('credential leak regression through the whole transport', () => {
+      it('should not leak the API key when fetch itself fails', async () => {
+        const failure = new TypeError('fetch failed', {
+          cause: Object.assign(new Error('getaddrinfo ENOTFOUND api.traveltimeapp.com'), {
+            code: 'ENOTFOUND',
+            options: { headers: { 'X-Api-Key': SENTINEL, Authorization: `Basic ${SENTINEL}` } },
+          }),
+        });
+        stubFetch(async () => { throw failure; });
+        const client = new TravelTimeClient({ apiKey: SENTINEL, applicationId: 'app-id' });
+
+        const err = await client.mapInfo().catch((e) => e);
+        expect(err).toBeInstanceOf(TravelTimeNetworkError);
+        expectNoSentinel(err);
+      });
+
+      it('should not leak the API key from a non-2xx JSON response with echoing headers', async () => {
+        stubFetch(async () => new Response(`<html>${SENTINEL} is not authorized</html>`, {
+          status: 500,
+          headers: { 'x-echoed-api-key': SENTINEL },
+        }));
+        const client = new TravelTimeClient({ apiKey: SENTINEL, applicationId: 'app-id' });
+
+        const err = await client.mapInfo().catch((e) => e);
+        expect(err).toBeInstanceOf(TravelTimeNetworkError);
+        expect(err.status).toBe(500);
+        expectNoSentinel(err);
+      });
+
+      it('should not leak Basic credentials from a proto 401', async () => {
+        stubFetch(async () => new Response(null, {
+          status: 401,
+          headers: { 'www-authenticate': 'Basic realm="proto"', 'x-echoed-authorization': `Basic ${SENTINEL}` },
+        }));
+        const client = new TravelTimeProtoClient({ apiKey: SENTINEL, applicationId: 'app-id' });
+
+        const err = await client.timeFilterFast({
+          country: 'uk',
+          departureLocation: { lat: 51.5, lng: -0.1 },
+          destinationCoordinates: [{ lat: 51.6, lng: -0.2 }],
+          transportation: 'driving',
+          travelTime: 3600,
+        }).catch((e) => e);
+
+        expect(err).toBeInstanceOf(TravelTimeNetworkError);
+        expect(err.status).toBe(401);
+        expectNoSentinel(err);
+      });
+
+      it('should not leak the API key from a timeout', async () => {
+        stubFetch(hangingFetch);
+        const client = new TravelTimeClient({ apiKey: SENTINEL, applicationId: 'app-id' }, { timeout: 20 });
+
+        const err = await client.mapInfo().catch((e) => e);
+        expect(err.code).toBe('ETIMEDOUT');
+        expectNoSentinel(err);
+      });
+    });
+  });
+});


### PR DESCRIPTION
Both clients now go through one shared transport built on Node's global `fetch`, leaving `protobufjs` as the only runtime dependency. `axios` and `agentkeepalive` are gone — keep-alive is the platform default, so nothing replaced them.

The transport applies a 120s per-attempt timeout where requests could previously hang forever, and retries `HTTP 429` with exponential backoff and jitter. Redirects are followed, as before, so API-side failover can reroute a request.

`fetch` does not throw on non-2xx, so error mapping splits: `fromJsonResponse`/`fromProtoResponse` map a response, `TravelTimeError.from` wraps a thrown failure. Thrown errors still hold only credential-free primitives.

Breaking: `axiosInstance`, `maxBodyLength` and `maxContentLength` options removed; `setCredentials`, `setBaseURL`, `setRateLimitSettings` and `getBaseURL` removed from both clients — credentials and base URL are constructor-only, with new `timeout` and `retry` options. `fromJsonError`/`fromProtoError` merged into `TravelTimeError.from`. Requests now time out after 120s.
