### PR TITLE
Map client failures at one boundary, typecheck the tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm ci
+      - run: npm run typecheck
       - run: npm run build
       - run: npm run test:unit
       # Constructing the proto client also proves the .proto files were copied.

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test": "vitest run",
     "test:unit": "vitest run --project unit",
     "test:integration": "vitest run --project integration",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc --noEmit && tsc -p tsconfig.test.json",
     "release": "npm run clean && npm i && npm run build && npm publish",
     "release-rc": "npm run clean && npm i && npm run build && npm publish --tag rc"
   },

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -92,22 +92,24 @@ function getHitAmountFromRequest(url: string, body: RequestPayload['body']) {
   }
 }
 
+const HPM_CHECKED_ENDPOINTS = new Set([
+  '/time-filter',
+  '/routes',
+  '/time-filter/postcode-districts',
+  '/time-filter/postcode-sectors',
+  '/time-filter/postcodes',
+  '/time-map/fast',
+  '/time-filter/fast',
+  '/time-map',
+  '/distance-map',
+  '/h3',
+  '/h3/fast',
+  '/geohash',
+  '/geohash/fast',
+]);
+
 function endpointChecksHPM(url: string) {
-  return [
-    '/time-filter',
-    '/routes',
-    '/time-filter/postcode-districts',
-    '/time-filter/postcode-sectors',
-    '/time-filter/postcodes',
-    '/time-map/fast',
-    '/time-filter/fast',
-    '/time-map',
-    '/distance-map',
-    '/h3',
-    '/h3/fast',
-    '/geohash',
-    '/geohash/fast',
-  ].includes(url);
+  return HPM_CHECKED_ENDPOINTS.has(url);
 }
 
 export class TravelTimeClient {
@@ -138,6 +140,14 @@ export class TravelTimeClient {
   }
 
   private async request<Response>(url: string, method: HttpMethod, payload?: RequestPayload): Promise<Response> {
+    try {
+      return await this.dispatch<Response>(url, method, payload);
+    } catch (error) {
+      throw TravelTimeError.from(error);
+    }
+  }
+
+  private async dispatch<Response>(url: string, method: HttpMethod, payload?: RequestPayload): Promise<Response> {
     const { body, config } = payload || {};
     const rq = async (): Promise<Response> => {
       const response = await this.transport.request(url, {
@@ -148,13 +158,7 @@ export class TravelTimeClient {
       });
       return parseResponseBody(response.body) as Response;
     };
-    if (!this.rateLimiter.isEnabled()) {
-      try {
-        return await rq();
-      } catch (error) {
-        throw TravelTimeError.from(error);
-      }
-    }
+    if (!this.rateLimiter.isEnabled()) return rq();
     // With the rate limiter enabled, the transport's own 429 retry is off and
     // retries are driven here instead, so a 429 can pause the whole queue.
     const isQuotaLimited = endpointChecksHPM(url);
@@ -175,18 +179,10 @@ export class TravelTimeClient {
     requestFn: T,
     bodies: Parameters<T>[0][],
   ): Promise<BatchResponse<R>[]> {
-    const results: BatchResponse<R>[] = [];
-
-    const chunkResults = await Promise.allSettled(bodies.map((request) => requestFn(request)));
-    chunkResults.forEach((chunkResult) => {
-      if (chunkResult.status === 'rejected') {
-        results.push({ type: 'error', error: chunkResult.reason });
-      } else {
-        results.push({ type: 'success', body: chunkResult.value });
-      }
-    });
-
-    return results;
+    const settled = await Promise.allSettled(bodies.map((requestBody) => requestFn(requestBody)));
+    return settled.map((result): BatchResponse<R> => (result.status === 'rejected'
+      ? { type: 'error', error: TravelTimeError.from(result.reason) }
+      : { type: 'success', body: result.value }));
   }
 
   async distanceMap(body: DistanceMapRequest): Promise<DistanceMapResponse>

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -67,7 +67,7 @@ function parseResponseBody(body: Buffer): unknown {
   }
 }
 
-function getHitAmountFromRequest(url: string, body: RequestPayload['body']) {
+function getHitAmountFromRequest(url: string, body: RequestPayload['body']): number | null {
   switch (url) {
     case '/time-filter':
     case '/routes':
@@ -88,28 +88,8 @@ function getHitAmountFromRequest(url: string, body: RequestPayload['body']) {
     case '/geohash': {
       return (body.departure_searches?.length || 0) + (body.arrival_searches?.length || 0) + (body.unions?.length || 0) + (body.intersections?.length || 0);
     }
-    default: return 0;
+    default: return null;
   }
-}
-
-const HPM_CHECKED_ENDPOINTS = new Set([
-  '/time-filter',
-  '/routes',
-  '/time-filter/postcode-districts',
-  '/time-filter/postcode-sectors',
-  '/time-filter/postcodes',
-  '/time-map/fast',
-  '/time-filter/fast',
-  '/time-map',
-  '/distance-map',
-  '/h3',
-  '/h3/fast',
-  '/geohash',
-  '/geohash/fast',
-]);
-
-function endpointChecksHPM(url: string) {
-  return HPM_CHECKED_ENDPOINTS.has(url);
 }
 
 export class TravelTimeClient {
@@ -161,10 +141,9 @@ export class TravelTimeClient {
     if (!this.rateLimiter.isEnabled()) return rq();
     // With the rate limiter enabled, the transport's own 429 retry is off and
     // retries are driven here instead, so a 429 can pause the whole queue.
-    const isQuotaLimited = endpointChecksHPM(url);
-    const hits = isQuotaLimited ? getHitAmountFromRequest(url, body || {}) : 0;
+    const hits = getHitAmountFromRequest(url, body || {});
     for (let retriesDone = 0; ; retriesDone += 1) {
-      if (isQuotaLimited) await this.rateLimiter.acquire(hits, retriesDone > 0);
+      if (hits !== null) await this.rateLimiter.acquire(hits, retriesDone > 0);
       try {
         return await rq();
       } catch (error) {

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -80,7 +80,7 @@ function getHitAmountFromRequest(url: string, body: RequestPayload['body']) {
     case '/time-filter/fast':
     case '/h3/fast':
     case '/geohash/fast': {
-      return (body.arrival_searches.one_to_many?.length || 0) + (body.arrival_searches.many_to_one?.length || 0);
+      return (body.arrival_searches?.one_to_many?.length || 0) + (body.arrival_searches?.many_to_one?.length || 0);
     }
     case '/distance-map':
     case '/time-map':

--- a/src/error.ts
+++ b/src/error.ts
@@ -186,6 +186,8 @@ export interface TravelTimeNetworkErrorParams {
   status?: number;
   url?: string;
   isRetryable?: boolean;
+  /** Adopt this stack rather than capturing one at construction. */
+  stack?: string;
 }
 
 /**
@@ -210,6 +212,7 @@ export class TravelTimeNetworkError extends TravelTimeError {
     // Every URL recorded on an error goes through sanitizeUrl, so no call
     // site can log a query string by accident
     this.url = sanitizeUrl(params.url);
+    if (params.stack !== undefined) this.stack = params.stack;
   }
 
   toJSON(): Record<string, any> {
@@ -252,8 +255,11 @@ export class TravelTimeNetworkError extends TravelTimeError {
         });
       }
       // No transport failure was observed — most likely a local
-      // encode/decode or programming error, which retrying cannot fix
-      return new TravelTimeNetworkError({ description: error.message || error.name, url, isRetryable: false });
+      // encode/decode or programming error, which retrying cannot fix. Its own
+      // stack points at the code that failed, so keep it.
+      return new TravelTimeNetworkError({
+        description: error.message || error.name, url, isRetryable: false, stack: error.stack,
+      });
     }
     return new TravelTimeNetworkError({ description: typeof error === 'string' ? error : 'Unknown request failure', url, isRetryable: false });
   }

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -1,3 +1,5 @@
+import { TravelTimeError } from '../error';
+
 export type Coords = {
   'lat': number;
   'lng': number;
@@ -182,7 +184,7 @@ export type LevelOfDetail = CoarseGridLevelOfDetail | SimpleLevelOfDetail| Simpl
 export type Credentials = { apiKey: string, applicationId: string }
 
 export interface BatchErrorResponse {
-  error: Error;
+  error: TravelTimeError;
   type: 'error';
 }
 

--- a/tests/unit/client.test.ts
+++ b/tests/unit/client.test.ts
@@ -1,0 +1,56 @@
+import {
+  describe, it, expect, vi, afterEach,
+} from 'vitest';
+import { TravelTimeClient, TravelTimeError, TimeMapFastRequest } from '../../src';
+
+/** The transport reads the global `fetch` at call time, so tests stub it. */
+function stubFetch(...statuses: number[]) {
+  let call = 0;
+  vi.stubGlobal('fetch', async () => {
+    const status = statuses[Math.min(call, statuses.length - 1)];
+    call += 1;
+    return status === 200
+      ? new Response(JSON.stringify({ results: [] }), { status })
+      : new Response(JSON.stringify({ error_code: 5, description: 'nope' }), { status });
+  });
+}
+
+const client = () => new TravelTimeClient({ apiKey: 'test-key', applicationId: 'app-id' });
+
+describe('TravelTimeClient batch', () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('reports a failed body as a TravelTimeError alongside the successes', async () => {
+    stubFetch(200, 400);
+    const results = await client().timeFilterBatch([
+      { departure_searches: [{ id: 'a' }] },
+      { departure_searches: [{ id: 'b' }] },
+    ] as never);
+
+    expect(results.map((r) => r.type)).toEqual(['success', 'error']);
+    const failed = results[1];
+    if (failed.type !== 'error') throw new Error('expected an error entry');
+    // BatchResponse.error is typed TravelTimeError, not Error, so consumers can
+    // read status and isRetryable without casting
+    expect(TravelTimeError.isTravelTimeError(failed.error)).toBe(true);
+    expect(failed.error.status).toBe(400);
+    expect(failed.error.isRetryable).toBe(false);
+  });
+});
+
+describe('TravelTimeClient error mapping boundary', () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('maps a failure raised while counting hits, instead of letting it escape raw', async () => {
+    stubFetch(200);
+    // /time-map/fast counts hits from arrival_searches; omitting it made hit
+    // counting throw a TypeError that escaped request() unmapped
+    const limited = new TravelTimeClient({ apiKey: 'test-key', applicationId: 'app-id' }, {
+      rateLimitSettings: { enabled: true, hitsPerMinute: 600 },
+    });
+
+    await expect(limited.timeMapFast({} as TimeMapFastRequest)).rejects.toSatisfy(
+      (error: unknown) => TravelTimeError.isTravelTimeError(error),
+    );
+  });
+});

--- a/tests/unit/client.test.ts
+++ b/tests/unit/client.test.ts
@@ -41,16 +41,29 @@ describe('TravelTimeClient batch', () => {
 describe('TravelTimeClient error mapping boundary', () => {
   afterEach(() => vi.unstubAllGlobals());
 
-  it('maps a failure raised while counting hits, instead of letting it escape raw', async () => {
+  it('maps a failure thrown before the request leaves, instead of letting it escape raw', async () => {
     stubFetch(200);
-    // /time-map/fast counts hits from arrival_searches; omitting it made hit
-    // counting throw a TypeError that escaped request() unmapped
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+
+    await expect(client().timeFilter(circular as never)).rejects.toSatisfy(
+      (error: unknown) => TravelTimeError.isTravelTimeError(error),
+    );
+  });
+
+  it('classifies a malformed body the same way whether the rate limiter is on or off', async () => {
+    stubFetch(400);
     const limited = new TravelTimeClient({ apiKey: 'test-key', applicationId: 'app-id' }, {
       rateLimitSettings: { enabled: true, hitsPerMinute: 600 },
     });
 
-    await expect(limited.timeMapFast({} as TimeMapFastRequest)).rejects.toSatisfy(
-      (error: unknown) => TravelTimeError.isTravelTimeError(error),
-    );
+    const [onLimiter, offLimiter] = await Promise.all([
+      limited.timeMapFast({} as TimeMapFastRequest).catch((error) => error),
+      client().timeMapFast({} as TimeMapFastRequest).catch((error) => error),
+    ]);
+
+    expect(onLimiter.name).toBe(offLimiter.name);
+    expect(onLimiter.status).toBe(400);
+    expect(offLimiter.status).toBe(400);
   });
 });

--- a/tests/unit/client.test.ts
+++ b/tests/unit/client.test.ts
@@ -3,12 +3,14 @@ import {
 } from 'vitest';
 import { TravelTimeClient, TravelTimeError, TimeMapFastRequest } from '../../src';
 
-/** The transport reads the global `fetch` at call time, so tests stub it. */
-function stubFetch(...statuses: number[]) {
-  let call = 0;
-  vi.stubGlobal('fetch', async () => {
-    const status = statuses[Math.min(call, statuses.length - 1)];
-    call += 1;
+/**
+ * The transport reads the global `fetch` at call time, so tests stub it. The
+ * status is chosen from the request body rather than the call order, so
+ * assertions hold however the requests interleave.
+ */
+function stubFetch(statusFor: (body: string) => number) {
+  vi.stubGlobal('fetch', async (_url: string, init: RequestInit) => {
+    const status = statusFor(String(init.body ?? ''));
     return status === 200
       ? new Response(JSON.stringify({ results: [] }), { status })
       : new Response(JSON.stringify({ error_code: 5, description: 'nope' }), { status });
@@ -21,7 +23,7 @@ describe('TravelTimeClient batch', () => {
   afterEach(() => vi.unstubAllGlobals());
 
   it('reports a failed body as a TravelTimeError alongside the successes', async () => {
-    stubFetch(200, 400);
+    stubFetch((body) => (body.includes('"b"') ? 400 : 200));
     const results = await client().timeFilterBatch([
       { departure_searches: [{ id: 'a' }] },
       { departure_searches: [{ id: 'b' }] },
@@ -42,7 +44,7 @@ describe('TravelTimeClient error mapping boundary', () => {
   afterEach(() => vi.unstubAllGlobals());
 
   it('maps a failure thrown before the request leaves, instead of letting it escape raw', async () => {
-    stubFetch(200);
+    stubFetch(() => 200);
     const circular: Record<string, unknown> = {};
     circular.self = circular;
 
@@ -52,7 +54,7 @@ describe('TravelTimeClient error mapping boundary', () => {
   });
 
   it('classifies a malformed body the same way whether the rate limiter is on or off', async () => {
-    stubFetch(400);
+    stubFetch(() => 400);
     const limited = new TravelTimeClient({ apiKey: 'test-key', applicationId: 'app-id' }, {
       rateLimitSettings: { enabled: true, hitsPerMinute: 600 },
     });

--- a/tests/unit/error.test.ts
+++ b/tests/unit/error.test.ts
@@ -226,6 +226,13 @@ describe('error model', () => {
     expect(TravelTimeError.isTravelTimeError(undefined)).toBe(false);
   });
 
+  it('should keep the original stack when sanitizing a local failure', () => {
+    const original = new Error('boom');
+    const mapped = TravelTimeNetworkError.from(original);
+    // a fresh stack would start inside error.ts rather than at the failing code
+    expect(mapped.stack).toBe(original.stack);
+  });
+
   it('should compute isRetryable from the kind of failure', () => {
     const cases: Array<[string, TravelTimeError, boolean]> = [
       ['429', new TravelTimeError({ description: 'too many requests', status: 429 }), true],

--- a/tests/unit/matrixMapper.test.ts
+++ b/tests/unit/matrixMapper.test.ts
@@ -5,7 +5,9 @@ import {
   timeFilterManyToManyMatrixResponseMapper,
   timeFilterFastManyToManyMatrixResponseMapper,
 } from '../../src/client/matrixMapper';
-import { BatchResponse, TimeFilterResponse, TimeFilterFastResponse } from '../../src';
+import {
+  BatchResponse, TimeFilterResponse, TimeFilterFastResponse, TravelTimeError,
+} from '../../src';
 
 describe('matrixMapper', () => {
   const coordsFrom = [
@@ -161,7 +163,7 @@ describe('matrixMapper', () => {
       const responses: BatchResponse<TimeFilterResponse>[] = [
         {
           type: 'error',
-          error: new Error('API error'),
+          error: new TravelTimeError({ description: 'API error' }),
         },
       ];
 

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "types": ["node", "vitest/globals"]
+  },
+  "include": ["src", "tests"]
+}


### PR DESCRIPTION
- `request()`'s body moves into `dispatch()` and `request()` wraps it once, so hit counting and rate limiter rejections can no longer escape as raw errors. Replaces three separate mapping sites.
- Sanitizing a local failure kept a fresh stack starting inside `error.ts`; `TravelTimeNetworkError` now adopts the original one.
- Hit counting dereferenced `arrival_searches` unguarded, so a malformed body failed locally with the limiter on and returned the API's 400 with it off. Both report the 400 now.
- `BatchResponse.error` is typed `TravelTimeError` instead of `Error`, so `status` and `isRetryable` need no cast.
- The quota-limited endpoint list duplicated the case labels in `getHitAmountFromRequest`, which now returns `null` when the endpoint is unmetered. Zero stays distinct — a metered body costing no hits still takes a pacing slot.
- Nothing typechecked the tests (`tsconfig` included only `src`, and CI ran no typecheck), which is how two stale-type breaks reached a branch. `tsconfig.test.json` covers both, and CI runs `typecheck` before `build`.
